### PR TITLE
Rewrite kemulator window size handling

### DIFF
--- a/src/main/emulator/Settings.java
+++ b/src/main/emulator/Settings.java
@@ -1,5 +1,7 @@
 package emulator;
 
+import emulator.ui.swt.ResizeMethod;
+
 import java.util.*;
 
 public final class Settings {
@@ -11,7 +13,7 @@ public final class Settings {
 	public static boolean alwaysOnTop;
 	public static boolean enableKeyCache;
 	public static boolean rightClickMenu;
-	public static int canvasScale = 100;
+	public static float canvasScale;
 	public static int frameRate = 60;
 	public static int steps = -1;
 	public static long aLong1235;
@@ -68,7 +70,7 @@ public final class Settings {
 	public static boolean synchronizeKeyEvents = true;
 	public static boolean motorolaSoftKeyFix = false;
 	public static int g3d = 1; // 0 - swerve, 1 - lwjgl
-	public static int resizeMode = 2; // 0 - center, 1 - sync, 2 - fill, 3 - integer
+	public static ResizeMethod resizeMode = ResizeMethod.Fit;
 	public static boolean keepAspectRatio = true;
 	public static boolean patchSynchronizedPaint = true;
 	public static boolean patchSynchronizedPlayerUpdate = true;

--- a/src/main/emulator/ui/swt/Property.java
+++ b/src/main/emulator/ui/swt/Property.java
@@ -623,11 +623,11 @@ public final class Property implements IProperty, SelectionListener {
 			}
 
 			// display
-			Settings.canvasScale = Integer.parseInt(properties.getProperty("CanvasScale", String.valueOf(100)));
-			if (Settings.canvasScale < 100 || Settings.canvasScale % 50 != 0) {
-				Settings.canvasScale = 100;
+			Settings.canvasScale = Integer.parseInt(properties.getProperty("CanvasScale", String.valueOf(1)))/100f;
+			if (Settings.canvasScale < 1f || Settings.canvasScale % 0.5f != 0) {
+				Settings.canvasScale = 1f;
 			}
-			Settings.resizeMode = Integer.parseInt(properties.getProperty("ResizeMode", "2"));
+			Settings.resizeMode = ResizeMethod.fromInt(Integer.parseInt(properties.getProperty("ResizeMode", "2")));
 			Settings.keepAspectRatio = Boolean.parseBoolean(properties.getProperty("KeepAspectRatio", "true"));
 
 			// window
@@ -636,7 +636,6 @@ public final class Property implements IProperty, SelectionListener {
 			EmulatorScreen.sizeW = Integer.parseInt(properties.getProperty("SizeW", "-1"));
 			EmulatorScreen.sizeH = Integer.parseInt(properties.getProperty("SizeH", "-1"));
 			EmulatorScreen.maximized = Boolean.parseBoolean(properties.getProperty("Maximized", "false"));
-			EmulatorScreen.defaultSize = Boolean.parseBoolean(properties.getProperty("DefaultSize", "true"));
 
 			Settings.alwaysOnTop = Boolean.parseBoolean(properties.getProperty("AlwaysOnTop", "false"));
 
@@ -854,8 +853,8 @@ public final class Property implements IProperty, SelectionListener {
 			properties.setProperty("TextAntiAliasing", String.valueOf(Settings.textAntiAliasing));
 
 			// display
-			properties.setProperty("CanvasScale", String.valueOf(Settings.canvasScale));
-			properties.setProperty("ResizeMode", String.valueOf(Settings.resizeMode));
+			properties.setProperty("CanvasScale", String.valueOf(Math.round(Settings.canvasScale*100)));
+			properties.setProperty("ResizeMode", Settings.resizeMode.toString());
 			properties.setProperty("KeepAspectRatio", String.valueOf(Settings.keepAspectRatio));
 
 			// window
@@ -864,7 +863,6 @@ public final class Property implements IProperty, SelectionListener {
 			properties.setProperty("SizeW", String.valueOf(EmulatorScreen.sizeW));
 			properties.setProperty("SizeH", String.valueOf(EmulatorScreen.sizeH));
 			properties.setProperty("Maximized", String.valueOf(EmulatorScreen.maximized));
-			properties.setProperty("DefaultSize", String.valueOf(EmulatorScreen.defaultSize));
 
 			properties.setProperty("AlwaysOnTop", String.valueOf(Settings.alwaysOnTop));
 

--- a/src/main/emulator/ui/swt/ResizeMethod.java
+++ b/src/main/emulator/ui/swt/ResizeMethod.java
@@ -1,0 +1,35 @@
+package emulator.ui.swt;
+
+/**
+ * Specifies how to fit canvas into OS window.
+ */
+public enum ResizeMethod {
+	/**
+	 * Canvas will be placed at window center. User will be able to manually zoom it in or out.
+	 */
+	Manual(0),
+	/**
+	 * Canvas will be sized to fully cover the window.
+	 */
+	FollowWindowSize(1),
+	/**
+	 * Canvas will be zoomed to cover the window, keeping aspect ratio.
+	 */
+	Fit(2),
+	FitInteger(3);
+
+	private final int id;
+
+	ResizeMethod(int i) {
+		id = i;
+	}
+
+	public static ResizeMethod fromInt(int value) {
+		return ResizeMethod.values()[value];
+	}
+
+	@Override
+	public String toString() {
+		return String.valueOf(id);
+	}
+}


### PR DESCRIPTION
Этот патч собирает все модификации параметров отображения канвы, раскиданные по разным обработчикам, в один единый метод. Из плюсов: в этом теперь возможно ориентироваться и понимать что вообще происходит. Судя по найденному одинаковому коду в двух методах с разными названиями, с этим были проблемы.

По поведению:
- Налажена обработка изменения высоты меню
- "Целый" автомасштаб теперь умеет уходить в минус (1/2, 1/3, 1/4 и т.д.)
- Изменение масштаба при активном автовписывании не трогает размер окна, вместо этого меняя как надо масштаб

Этот патч всё ещё не готов и дописывается/тестируется мной.