### PR TITLE
Abstract out SWT screen

### DIFF
--- a/src/3d/emulator/graphics3D/lwjgl/Emulator3D.java
+++ b/src/3d/emulator/graphics3D/lwjgl/Emulator3D.java
@@ -11,7 +11,7 @@ import emulator.graphics3D.Transform3D;
 import emulator.graphics3D.Vector4f;
 import emulator.graphics3D.egl.GLConfiguration;
 import emulator.graphics3D.m3g.*;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import emulator.ui.swt.EmulatorScreen;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ControlListener;
@@ -179,7 +179,7 @@ public final class Emulator3D implements IGraphics3D {
 		try {
 			if (targetWidth != w || targetHeight != h) {
 				if (glCanvas != null) {
-					EmulatorImpl.asyncExec(new Runnable() {
+					SWTFrontend.asyncExec(new Runnable() {
 						public void run() {
 							glCanvas.setSize(w, h);
 							glCanvas.setVisible(false);
@@ -1319,7 +1319,7 @@ public final class Emulator3D implements IGraphics3D {
 
 	private void disposeGlCanvas() {
 		if (glCanvas == null) return;
-		EmulatorImpl.syncExec(new Runnable() {
+		SWTFrontend.syncExec(new Runnable() {
 			public void run() {
 				glCanvas.dispose();
 				glCanvas = null;
@@ -1373,7 +1373,7 @@ public final class Emulator3D implements IGraphics3D {
 			if (exiting) return;
 			int mode = Settings.m3gContextMode == 0 && Emulator.win ? 2 : Settings.m3gContextMode;
 			if (!forceWindow && Settings.m3gContextMode != 3) {
-				EmulatorImpl.syncExec(new Runnable() {
+				SWTFrontend.syncExec(new Runnable() {
 					public void run() {
 						try {
 							Composite parent = ((EmulatorScreen) Emulator.getEmulator().getScreen()).getCanvas();
@@ -1392,7 +1392,7 @@ public final class Emulator3D implements IGraphics3D {
 				GLCanvasUtil.makeCurrent(glCanvas);
 				getCapabilities();
 
-				EmulatorImpl.syncExec(new Runnable() {
+				SWTFrontend.syncExec(new Runnable() {
 					public void run() {
 						glCanvas.addControlListener(new ControlListener() {
 							public void controlMoved(ControlEvent controlEvent) {

--- a/src/3d/emulator/graphics3D/view/M3GView3D.java
+++ b/src/3d/emulator/graphics3D/view/M3GView3D.java
@@ -12,7 +12,7 @@ import emulator.graphics3D.m3g.LightsCache;
 import emulator.graphics3D.m3g.MeshMorph;
 import emulator.graphics3D.m3g.RenderObject;
 import emulator.graphics3D.m3g.RenderPipe;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.graphics.GC;
@@ -419,7 +419,7 @@ public final class M3GView3D implements PaintListener, Runnable {
 			glfwMakeContextCurrent(window);
 			getCapabilities();
 
-			EmulatorImpl.syncExec(this);
+			SWTFrontend.syncExec(this);
 		}
 		hints();
 
@@ -483,7 +483,7 @@ public final class M3GView3D implements PaintListener, Runnable {
 				var10 -= var8;
 			}
 		}
-		EmulatorImpl.syncExec(this);
+		SWTFrontend.syncExec(this);
 	}
 
 	public void run() {

--- a/src/main/emulator/Emulator.java
+++ b/src/main/emulator/Emulator.java
@@ -138,7 +138,7 @@ public class Emulator implements Runnable {
 
 	public static void setCanvas(final Canvas canvas) {
 		Emulator.currentCanvas = canvas;
-		Emulator.emulatorimpl.getEmulatorScreen().setCurrent(canvas);
+		Emulator.emulatorimpl.getScreen().setCurrent(canvas);
 	}
 
 	public static Screen getScreen() {
@@ -147,7 +147,7 @@ public class Emulator implements Runnable {
 
 	public static void setScreen(final Screen screen) {
 		Emulator.currentScreen = screen;
-		Emulator.emulatorimpl.getEmulatorScreen().setCurrent(screen);
+		Emulator.emulatorimpl.getScreen().setCurrent(screen);
 	}
 
 	public static MIDlet getMIDlet() {
@@ -489,7 +489,7 @@ public class Emulator implements Runnable {
 						// must have to load device before screen is initialized
 						loadTargetDevice();
 
-						int n = emulatorimpl.getEmulatorScreen().showMidletChoice(midletKeys);
+						int n = emulatorimpl.getScreen().showMidletChoice(midletKeys);
 						if (n == -1) {
 							CustomMethod.close();
 							System.exit(0);
@@ -531,7 +531,7 @@ public class Emulator implements Runnable {
 		} catch (Exception ex) {
 			if (ex.toString().equalsIgnoreCase("java.io.IOException: Negative seek offset")) {
 				ex.printStackTrace();
-				Emulator.emulatorimpl.getEmulatorScreen().showMessage(UILocale.get("LOAD_ZIP_ERROR", "Input file is not JAR or ZIP archive."), CustomMethod.getStackTrace(ex));
+				Emulator.emulatorimpl.getScreen().showMessage(UILocale.get("LOAD_ZIP_ERROR", "Input file is not JAR or ZIP archive."), CustomMethod.getStackTrace(ex));
 				return false;
 			}
 			throw ex;
@@ -794,12 +794,12 @@ public class Emulator implements Runnable {
 			initRichPresence();
 
 			if (Settings.autoUpdate == 0) {
-				Settings.autoUpdate = updated ? 2 : Emulator.emulatorimpl.getEmulatorScreen().showUpdateDialog(0);
+				Settings.autoUpdate = updated ? 2 : Emulator.emulatorimpl.getScreen().showUpdateDialog(0);
 			}
 			backgroundThread.start();
 
 			if (Emulator.midletClassName == null && Emulator.midletJar == null) {
-				Emulator.emulatorimpl.getEmulatorScreen().start(false);
+				Emulator.emulatorimpl.getScreen().startEmpty();
 				EmulatorImpl.dispose();
 				System.exit(0);
 				return;
@@ -808,13 +808,13 @@ public class Emulator implements Runnable {
 			getLibraries();
 			try {
 				if (!getJarClasses()) {
-					Emulator.emulatorimpl.getEmulatorScreen().showMessage(UILocale.get("LOAD_CLASSES_ERROR", "Get Classes Failed!! Plz check the input jar or classpath."));
+					Emulator.emulatorimpl.getScreen().showMessage(UILocale.get("LOAD_CLASSES_ERROR", "Get Classes Failed!! Plz check the input jar or classpath."));
 					System.exit(1);
 					return;
 				}
 			} catch (Exception e) {
 				e.printStackTrace();
-				Emulator.emulatorimpl.getEmulatorScreen().showMessage(UILocale.get("LOAD_CLASSES_ERROR", "Get Classes Failed!! Plz check the input jar or classpath."), CustomMethod.getStackTrace(e));
+				Emulator.emulatorimpl.getScreen().showMessage(UILocale.get("LOAD_CLASSES_ERROR", "Get Classes Failed!! Plz check the input jar or classpath."), CustomMethod.getStackTrace(e));
 				System.exit(1);
 				return;
 			}
@@ -840,10 +840,10 @@ public class Emulator implements Runnable {
 				Emulator.rpcDetails = Settings.uei ? "UEI" : new File(midletJar).getName();
 				updatePresence();
 			}
-			Emulator.emulatorimpl.getEmulatorScreen().setWindowIcon(inputStream);
+			Emulator.emulatorimpl.getScreen().setWindowIcon(inputStream);
 			setProperties();
 			if (Emulator.midletClassName == null) {
-				Emulator.emulatorimpl.getEmulatorScreen().showMessage(UILocale.get("LOAD_MIDLET_ERROR", "Can not find MIDlet class. Plz check jad or use -midlet param."));
+				Emulator.emulatorimpl.getScreen().showMessage(UILocale.get("LOAD_MIDLET_ERROR", "Can not find MIDlet class. Plz check jad or use -midlet param."));
 				System.exit(1);
 				return;
 			}
@@ -852,13 +852,13 @@ public class Emulator implements Runnable {
 				midletClass = Class.forName(Emulator.midletClassName = Emulator.midletClassName.replace('/', '.'), true, Emulator.customClassLoader);
 			} catch (Throwable e) {
 				e.printStackTrace();
-				Emulator.emulatorimpl.getEmulatorScreen().showMessage(UILocale.get("FAIL_LAUNCH_MIDLET", "Fail to launch the MIDlet class:") + " " + Emulator.midletClassName, CustomMethod.getStackTrace(e));
+				Emulator.emulatorimpl.getScreen().showMessage(UILocale.get("FAIL_LAUNCH_MIDLET", "Fail to launch the MIDlet class:") + " " + Emulator.midletClassName, CustomMethod.getStackTrace(e));
 				System.exit(1);
 				return;
 			}
 			Emulator.eventQueue = new EventQueue();
 			new Thread(new Emulator()).start();
-			Emulator.emulatorimpl.getEmulatorScreen().start(true);
+			Emulator.emulatorimpl.getScreen().startWithMidlet();
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
@@ -1238,7 +1238,7 @@ public class Emulator implements Runnable {
 				if (!updated && !Settings.uei && Settings.autoUpdate == 2 && Updater.checkUpdate() == Updater.STATE_UPDATE_AVAILABLE) {
 					EmulatorImpl.asyncExec(new Runnable() {
 						public void run() {
-							Emulator.emulatorimpl.getEmulatorScreen().showUpdateDialog(1);
+							Emulator.emulatorimpl.getScreen().showUpdateDialog(1);
 						}
 					});
 				}
@@ -1299,7 +1299,7 @@ public class Emulator implements Runnable {
 			Emulator.eventQueue.stop();
 			EmulatorImpl.syncExec(new Runnable() {
 				public void run() {
-					Emulator.emulatorimpl.getEmulatorScreen().showMessage(UILocale.get("FAIL_LAUNCH_MIDLET", "Fail to launch the MIDlet class:") + " " + Emulator.midletClassName, CustomMethod.getStackTrace(e));
+					Emulator.emulatorimpl.getScreen().showMessage(UILocale.get("FAIL_LAUNCH_MIDLET", "Fail to launch the MIDlet class:") + " " + Emulator.midletClassName, CustomMethod.getStackTrace(e));
 				}
 			});
 			return;

--- a/src/main/emulator/Emulator.java
+++ b/src/main/emulator/Emulator.java
@@ -9,8 +9,8 @@ import emulator.custom.CustomMethod;
 import emulator.graphics3D.IGraphics3D;
 import emulator.media.EmulatorMIDI;
 import emulator.media.MMFPlayer;
-import emulator.ui.IEmulator;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.IEmulatorFrontend;
+import emulator.ui.swt.SWTFrontend;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipFile;
 
@@ -38,7 +38,7 @@ public class Emulator implements Runnable {
 	public static String revision = "";
 	public static final int numericVersion = 32;
 
-	static EmulatorImpl emulatorimpl;
+	private static SWTFrontend emulatorimpl;
 	private static MIDlet midlet;
 	private static Canvas currentCanvas;
 	private static Screen currentScreen;
@@ -124,8 +124,8 @@ public class Emulator implements Runnable {
 		super();
 	}
 
-	public static IEmulator getEmulator() {
-		return Emulator.emulatorimpl;
+	public static IEmulatorFrontend getEmulator() {
+		return emulatorimpl;
 	}
 
 	public static KeyRecords getRobot() {
@@ -771,7 +771,7 @@ public class Emulator implements Runnable {
 			Emulator.commandLineArguments = commandLineArguments;
 			UILocale.initLocale();
 			parseLaunchArgs(commandLineArguments); //
-			Emulator.emulatorimpl = new EmulatorImpl();
+			Emulator.emulatorimpl = new SWTFrontend();
 			parseLaunchArgs(commandLineArguments);
 			// Force m3g engine to LWJGL in x64 build
 			if (platform.isX64()) Settings.micro3d = Settings.g3d = 1;
@@ -800,7 +800,7 @@ public class Emulator implements Runnable {
 
 			if (Emulator.midletClassName == null && Emulator.midletJar == null) {
 				Emulator.emulatorimpl.getScreen().startEmpty();
-				EmulatorImpl.dispose();
+				emulatorimpl.dispose();
 				System.exit(0);
 				return;
 			}
@@ -863,7 +863,7 @@ public class Emulator implements Runnable {
 			e.printStackTrace();
 		}
 		try {
-			EmulatorImpl.dispose();
+			emulatorimpl.dispose();
 		} catch (Throwable ignored) {
 		}
 		System.exit(0);
@@ -1236,7 +1236,7 @@ public class Emulator implements Runnable {
 			public void run() {
 				Manager.checkLibVlcSupport();
 				if (!updated && !Settings.uei && Settings.autoUpdate == 2 && Updater.checkUpdate() == Updater.STATE_UPDATE_AVAILABLE) {
-					EmulatorImpl.asyncExec(new Runnable() {
+					SWTFrontend.asyncExec(new Runnable() {
 						public void run() {
 							Emulator.emulatorimpl.getScreen().showUpdateDialog(1);
 						}
@@ -1297,7 +1297,7 @@ public class Emulator implements Runnable {
 		} catch (Throwable e) {
 			e.printStackTrace();
 			Emulator.eventQueue.stop();
-			EmulatorImpl.syncExec(new Runnable() {
+			SWTFrontend.syncExec(new Runnable() {
 				public void run() {
 					Emulator.emulatorimpl.getScreen().showMessage(UILocale.get("FAIL_LAUNCH_MIDLET", "Fail to launch the MIDlet class:") + " " + Emulator.midletClassName, CustomMethod.getStackTrace(e));
 				}

--- a/src/main/emulator/Permission.java
+++ b/src/main/emulator/Permission.java
@@ -83,7 +83,7 @@ public class Permission {
 			return null;
 		if (!askImei) return "0000000000000000";
 		if (imei != null) return imei;
-		String s = Emulator.emulatorimpl.getScreen().showIMEIDialog();
+		String s = Emulator.getEmulator().getScreen().showIMEIDialog();
 		if (s == null) {
 			notAllowPerms.add("imei");
 		}
@@ -92,7 +92,7 @@ public class Permission {
 	}
 
 	public static boolean showConfirmDialog(final String message) {
-		return Emulator.emulatorimpl.getScreen().showSecurityDialog(message);
+		return Emulator.getEmulator().getScreen().showSecurityDialog(message);
 	}
 
 	public static void checkPermission(String x) {
@@ -177,6 +177,6 @@ public class Permission {
 					": " + url);
 		}
 
-		return Emulator.emulatorimpl.getScreen().showSecurityDialog(text);
+		return Emulator.getEmulator().getScreen().showSecurityDialog(text);
 	}
 }

--- a/src/main/emulator/custom/CustomMethod.java
+++ b/src/main/emulator/custom/CustomMethod.java
@@ -6,7 +6,7 @@ import emulator.Settings;
 import emulator.custom.h.MethodInfo;
 import emulator.debug.Profiler;
 import emulator.graphics3D.lwjgl.Emulator3D;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import emulator.ui.swt.EmulatorScreen;
 
 import javax.microedition.media.Manager;
@@ -110,11 +110,7 @@ public class CustomMethod {
 						}
 						Settings.customTitle = res;
 
-						EmulatorImpl.syncExec(new Runnable() {
-							public void run() {
-								((EmulatorScreen) Emulator.getEmulator().getScreen()).updateTitle();
-							}
-						});
+						Emulator.getEmulator().getScreen().updateTitle();
 						res = "true";
 					}
 				} catch (Exception ignored) {}

--- a/src/main/emulator/debug/Memory.java
+++ b/src/main/emulator/debug/Memory.java
@@ -18,6 +18,7 @@ import java.io.*;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
@@ -338,9 +339,7 @@ public final class Memory {
 				method849(clazz.getSuperclass(), vector);
 			}
 			final Field[] declaredFields = clazz.getDeclaredFields();
-			for (int i = 0; i < declaredFields.length; ++i) {
-				vector.add(declaredFields[i]);
-			}
+			Collections.addAll(vector, declaredFields);
 		} catch (Error ignored) {
 		}
 	}
@@ -374,7 +373,7 @@ public final class Memory {
 		return n;
 	}
 
-	public final int objectsSize() {
+	public int objectsSize() {
 		int n = 0;
 		final Enumeration<ClassInfo> elements = this.classesTable.elements();
 		while (elements.hasMoreElements()) {
@@ -575,12 +574,12 @@ public final class Memory {
 							String s = sound.getExportName();
 							if (b != null) {
 								exportAudio(b, sound.getExportName());
-								((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Saved: " + s);
+								Emulator.getEmulator().getScreen().showMessage("Saved: " + s);
 							} else {
-								((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Export failed: unsupported stream type");
+								Emulator.getEmulator().getScreen().showMessage("Export failed: unsupported stream type");
 							}
 						} catch (Exception e) {
-							((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Export failed: " + e.toString());
+							Emulator.getEmulator().getScreen().showMessage("Export failed: " + e);
 						}
 						break;
 					}
@@ -610,12 +609,12 @@ public final class Memory {
 						String s = audioClip.getExportName();
 						if (b != null) {
 							exportAudio(b, s);
-							((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Saved: " + s);
+							Emulator.getEmulator().getScreen().showMessage("Saved: " + s);
 						} else {
-							((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Export failed: unsupported stream type");
+							Emulator.getEmulator().getScreen().showMessage("Export failed: unsupported stream type");
 						}
 					} catch (Exception e) {
-						((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Export failed: " + e.toString());
+						Emulator.getEmulator().getScreen().showMessage("Export failed: " + e);
 					}
 					break;
 				}
@@ -640,7 +639,7 @@ public final class Memory {
 						break;
 					}
 					case export: {
-						((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Export not supported!");
+						Emulator.getEmulator().getScreen().showMessage("Export not supported!");
 						break;
 					}
 				}
@@ -675,12 +674,12 @@ public final class Memory {
 						String s = "audio" + playerImpl.getExportName();
 						if (b != null) {
 							exportAudio(b, s);
-							((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Saved: " + s);
+							Emulator.getEmulator().getScreen().showMessage("Saved: " + s);
 						} else {
-							((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Export failed: unsupported stream type");
+							Emulator.getEmulator().getScreen().showMessage("Export failed: unsupported stream type");
 						}
 					} catch (Exception e) {
-						((EmulatorScreen) Emulator.getEmulator().getScreen()).showMessage("Export failed: " + e.toString());
+						Emulator.getEmulator().getScreen().showMessage("Export failed: " + e);
 					}
 				}
 			}
@@ -845,7 +844,7 @@ public final class Memory {
 		int anInt1487;
 		Vector objs;
 
-		public final int size() {
+		public int size() {
 			int anInt1487 = this.anInt1487;
 			for (int i = this.objs.size() - 1; i >= 0; --i) {
 				anInt1487 += ((ObjInstance) this.objs.get(i)).size;
@@ -853,7 +852,7 @@ public final class Memory {
 			return anInt1487;
 		}
 
-		public final int compareTo(final Object o) {
+		public int compareTo(final Object o) {
 			return this.s.compareTo(((ClassInfo) o).s);
 		}
 

--- a/src/main/emulator/graphics2D/swt/FontSWT.java
+++ b/src/main/emulator/graphics2D/swt/FontSWT.java
@@ -1,7 +1,7 @@
 package emulator.graphics2D.swt;
 
 import emulator.graphics2D.IFont;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
@@ -37,7 +37,7 @@ public final class FontSWT implements IFont {
 
 
 	public final void finalize() {
-		EmulatorImpl.asyncExec(() -> {
+		SWTFrontend.asyncExec(() -> {
 			try {
 				if (font != null && !font.isDisposed()) {
 					font.dispose();

--- a/src/main/emulator/graphics2D/swt/Graphics2DSWT.java
+++ b/src/main/emulator/graphics2D/swt/Graphics2DSWT.java
@@ -4,7 +4,7 @@ import emulator.graphics2D.IFont;
 import emulator.graphics2D.IGraphics2D;
 import emulator.graphics2D.IImage;
 import emulator.graphics2D.ITransform;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.*;
 
@@ -31,7 +31,7 @@ public final class Graphics2DSWT implements IGraphics2D {
 	}
 
 	public final void finalize() {
-		EmulatorImpl.asyncExec(() -> {
+		SWTFrontend.asyncExec(() -> {
 			try {
 				if (!gc.isDisposed()) {
 					gc.dispose();

--- a/src/main/emulator/graphics2D/swt/ImageSWT.java
+++ b/src/main/emulator/graphics2D/swt/ImageSWT.java
@@ -2,7 +2,7 @@ package emulator.graphics2D.swt;
 
 import emulator.graphics2D.IGraphics2D;
 import emulator.graphics2D.IImage;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import org.eclipse.swt.graphics.*;
 
 import javax.imageio.ImageIO;
@@ -78,7 +78,7 @@ public final class ImageSWT implements IImage {
 	}
 
 	public final void finalize() {
-		EmulatorImpl.asyncExec(() -> {
+		SWTFrontend.asyncExec(() -> {
 			try {
 				if (img != null && !img.isDisposed()) {
 					img.dispose();

--- a/src/main/emulator/ui/IEmulatorFrontend.java
+++ b/src/main/emulator/ui/IEmulatorFrontend.java
@@ -6,7 +6,7 @@ import emulator.graphics3D.IGraphics3D;
 
 import java.io.IOException;
 
-public interface IEmulator {
+public interface IEmulatorFrontend {
 	IMessage getMessage();
 
 	ILogStream getLogStream();
@@ -37,6 +37,7 @@ public interface IEmulator {
 
 	String getAppProperty(final String p0);
 
-    void updateLanguage();
+	void updateLanguage();
 
+	void dispose();
 }

--- a/src/main/emulator/ui/IScreen.java
+++ b/src/main/emulator/ui/IScreen.java
@@ -2,6 +2,9 @@ package emulator.ui;
 
 import emulator.graphics2D.IImage;
 
+import java.io.InputStream;
+import java.util.Vector;
+
 public interface IScreen {
 	IImage getScreenImg();
 
@@ -27,5 +30,25 @@ public interface IScreen {
 
 	void setSize(int w, int h);
 
+	void setWindowIcon(final InputStream inputStream);
+
 	void showMessage(final String message);
+
+	void showMessage(final String title, final String detail);
+
+	int showMidletChoice(Vector<String> midletKeys);
+
+	int showUpdateDialog(int type);
+
+	boolean showSecurityDialog(final String message);
+
+	String showIMEIDialog();
+
+	void setCurrent(final javax.microedition.lcdui.Displayable d);
+
+	void updateTitle();
+
+	void startWithMidlet();
+
+	void startEmpty();
 }

--- a/src/main/emulator/ui/swt/About.java
+++ b/src/main/emulator/ui/swt/About.java
@@ -233,7 +233,7 @@ public final class About implements MouseListener, MouseMoveListener {
 
 		public final void run() {
 			About.method457(this.aClass54_775).method136(this.aClass54_775.anIntArray815, this.aClass54_775.anIntArray818);
-			EmulatorImpl.syncExec(new Water(this, aClass54_775.ana811));
+			SWTFrontend.syncExec(new Water(this, aClass54_775.ana811));
 		}
 
 		WaterTask(final About class54, final Class158 class55) {
@@ -246,7 +246,7 @@ public final class About implements MouseListener, MouseMoveListener {
 	}
 
 	public void finalize() {
-		EmulatorImpl.asyncExec(() -> {
+		SWTFrontend.asyncExec(() -> {
 			try {
 				if (!aGC814.isDisposed()) aGC814.dispose();
 			} catch (Exception ignored) {

--- a/src/main/emulator/ui/swt/CaretImpl.java
+++ b/src/main/emulator/ui/swt/CaretImpl.java
@@ -41,7 +41,7 @@ public final class CaretImpl implements ICaret, ModifyListener, TraverseListener
 
 	public final int getCaretPosition() {
 		if (swtText == null || currentItem == null) return 0;
-		EmulatorImpl.syncExec( new Runnable() {
+		SWTFrontend.syncExec(new Runnable() {
 			public void run() {
 				try {
 					caretPosition = swtText.getCaretPosition();
@@ -58,7 +58,7 @@ public final class CaretImpl implements ICaret, ModifyListener, TraverseListener
 
 	public void setCaret(final int index) {
 		if (swtText == null || currentItem == null) return;
-		EmulatorImpl.syncExec( new Runnable() {
+		SWTFrontend.syncExec(new Runnable() {
 			public void run() {
 				try {
 					swtText.setSelection(index);
@@ -69,7 +69,7 @@ public final class CaretImpl implements ICaret, ModifyListener, TraverseListener
 
 	public void setSelection(final int index, final int length) {
 		if (swtText == null || currentItem == null) return;
-		EmulatorImpl.syncExec( new Runnable() {
+		SWTFrontend.syncExec(new Runnable() {
 			public void run() {
 				try {
 					swtText.setSelection(index, length);
@@ -149,7 +149,7 @@ public final class CaretImpl implements ICaret, ModifyListener, TraverseListener
 		}
 
 		final Object lastItem = tmp;
-		EmulatorImpl.syncExec(new Runnable() {
+		SWTFrontend.syncExec(new Runnable() {
 			public final void run() {
 				if (lastItem != item && swtText != null) {
 					if (!swtText.isDisposed()) swtText.dispose();
@@ -199,7 +199,7 @@ public final class CaretImpl implements ICaret, ModifyListener, TraverseListener
 		} else if (tmp instanceof TextField) {
 			((TextField) tmp)._swtFocusLost();
 		}
-		EmulatorImpl.syncExec(new Runnable() {
+		SWTFrontend.syncExec(new Runnable() {
 			public final void run() {
 				if (swtText != null && !swtText.isDisposed()) {
 					swtText.dispose();
@@ -214,7 +214,7 @@ public final class CaretImpl implements ICaret, ModifyListener, TraverseListener
 
 	public void updateText(Object item, final String text) {
 		if (item != this.currentItem || swtText == null) return;
-		EmulatorImpl.syncExec(new Runnable() {
+		SWTFrontend.syncExec(new Runnable() {
 			public final void run() {
 				try {
 					swtText.setText(text);

--- a/src/main/emulator/ui/swt/EmulatorImpl.java
+++ b/src/main/emulator/ui/swt/EmulatorImpl.java
@@ -29,7 +29,7 @@ public final class EmulatorImpl implements IEmulator {
 	private Watcher classWatcher;
 	private Watcher profiler;
 	private Property iproperty;
-	private EmulatorScreen iscreen;
+	private EmulatorScreen screen;
 	private Log ilogstream;
 	private KeyPad keyPad;
 	private InfosBox infos;
@@ -77,13 +77,6 @@ public final class EmulatorImpl implements IEmulator {
 
 	public final int getScreenDepth() {
 		return this.screenDepth;
-	}
-
-	public final EmulatorScreen getEmulatorScreen() {
-		if (this.iscreen == null) {
-			this.iscreen = new EmulatorScreen(Devices.getPropertyInt("SCREEN_WIDTH"), Devices.getPropertyInt("SCREEN_HEIGHT"));
-		}
-		return this.iscreen;
 	}
 
 	public final Watcher getClassWatcher() {
@@ -163,7 +156,10 @@ public final class EmulatorImpl implements IEmulator {
 	}
 
 	public final IScreen getScreen() {
-		return this.iscreen;
+		if (screen == null) {
+			screen = new EmulatorScreen(Devices.getPropertyInt("SCREEN_WIDTH"), Devices.getPropertyInt("SCREEN_HEIGHT"));
+		}
+		return screen;
 	}
 
 	public final IMessage getMessage() {
@@ -249,6 +245,6 @@ public final class EmulatorImpl implements IEmulator {
 	 * updateLanguage
 	 */
 	public void updateLanguage() {
-		getEmulatorScreen().updateLanguage();
+		((EmulatorScreen) getScreen()).updateLanguage();
 	}
 }

--- a/src/main/emulator/ui/swt/EmulatorScreen.java
+++ b/src/main/emulator/ui/swt/EmulatorScreen.java
@@ -189,7 +189,7 @@ public final class EmulatorScreen implements
 
 	public EmulatorScreen(final int n, final int n2) {
 		this.pauseStateStrings = new String[]{UILocale.get("MAIN_INFO_BAR_UNLOADED", "UNLOADED"), UILocale.get("MAIN_INFO_BAR_RUNNING", "RUNNING"), UILocale.get("MAIN_INFO_BAR_PAUSED", "PAUSED")};
-		EmulatorScreen.display = SWTFrontend.getDisplay();
+		display = SWTFrontend.getDisplay();
 		this.initShell();
 		this.initScreenBuffer(startWidth = n, startHeight = n2);
 		this.updatePauseState();
@@ -272,8 +272,8 @@ public final class EmulatorScreen implements
 		shell.setLocation(clientArea.x + (clientArea.width - size.x) / 2, clientArea.y + (clientArea.height - size.y) / 2);
 		shell.open();
 		while (!shell.isDisposed()) {
-			if (!EmulatorScreen.display.readAndDispatch()) {
-				EmulatorScreen.display.sleep();
+			if (!display.readAndDispatch()) {
+				display.sleep();
 			}
 		}
 	}
@@ -319,7 +319,7 @@ public final class EmulatorScreen implements
 			return;
 		}
 
-		Rectangle clientArea = EmulatorScreen.display.getPrimaryMonitor().getClientArea();
+		Rectangle clientArea = display.getPrimaryMonitor().getClientArea();
 		if (EmulatorScreen.locX == Integer.MIN_VALUE) {
 			EmulatorScreen.locX = clientArea.x - (clientArea.width + this.shell.getSize().x) >> 1;
 		}
@@ -328,8 +328,8 @@ public final class EmulatorScreen implements
 		}
 		this.shell.setLocation(EmulatorScreen.locX, EmulatorScreen.locY);
 //		EmulatorImpl.asyncExec(new WindowOpen(this, 0));
-		SWTFrontend.asyncExec(new WindowOpen(this, 1));
-		SWTFrontend.asyncExec(new WindowOpen(this, 2));
+		display.asyncExec(new WindowOpen(this, 1));
+		display.asyncExec(new WindowOpen(this, 2));
 
 		if (midletLoaded) {
 			String s = Emulator.getEmulator().getAppProperty("Nokia-UI-Enhancement");
@@ -372,8 +372,8 @@ public final class EmulatorScreen implements
 		try {
 			while (this.shell != null && !this.shell.isDisposed()) {
 				//pollKeyboard(canvas);
-				if (!EmulatorScreen.display.readAndDispatch()) {
-					EmulatorScreen.display.sleep();
+				if (!display.readAndDispatch()) {
+					display.sleep();
 				}
 			}
 		} catch (Error e) {
@@ -689,7 +689,7 @@ public final class EmulatorScreen implements
 		}
 		if (this.pauseState == 2) {
 			gc.setAlpha(100);
-			gc.setBackground(EmulatorScreen.display.getSystemColor(15));
+			gc.setBackground(display.getSystemColor(15));
 			gc.fillRectangle(0, 0, this.getWidth(), this.getHeight());
 		}
 		gc.dispose();
@@ -765,10 +765,10 @@ public final class EmulatorScreen implements
 		if (Settings.asyncFlush) {
 			if (paintPending) return;
 			paintPending = true;
-			SWTFrontend.asyncExec(this);
+			display.asyncExec(this);
 			return;
 		}
-		SWTFrontend.syncExec(this);
+		display.syncExec(this);
 	}
 
 	public int getWidth() {
@@ -781,12 +781,12 @@ public final class EmulatorScreen implements
 
 	public void setCommandLeft(final String text) {
 		this.leftCmdText = text;
-		SWTFrontend.syncExec(new Class41(this));
+		display.syncExec(new Class41(this));
 	}
 
 	public void setCommandRight(final String text) {
 		this.rightCmdText = text;
-		SWTFrontend.syncExec(new Class40(this));
+		display.syncExec(new Class40(this));
 	}
 
 
@@ -1437,7 +1437,7 @@ public final class EmulatorScreen implements
 					public void run() {
 						Updater.checkUpdate();
 						if (Updater.state == Updater.STATE_UPDATE_AVAILABLE) {
-							SWTFrontend.asyncExec(new Runnable() {
+							display.asyncExec(new Runnable() {
 								public void run() {
 									showUpdateDialog(1);
 								}
@@ -1445,7 +1445,7 @@ public final class EmulatorScreen implements
 							return;
 						}
 						if (Updater.state == Updater.STATE_UP_TO_DATE) {
-							SWTFrontend.syncExec(new Runnable() {
+							display.syncExec(new Runnable() {
 								public void run() {
 									showMessage(UILocale.get("UPDATE_ALREADY_LATEST_TEXT", "You already have the latest version of KEmulator."));
 								}
@@ -1486,11 +1486,11 @@ public final class EmulatorScreen implements
 			if (menuItem == this.infosMenuItem) {
 				this.infosEnabled = this.infosMenuItem.getSelection();
 				if (this.infosEnabled) {
-					this.canvas.setCursor(new Cursor(EmulatorScreen.display, 2));
+					this.canvas.setCursor(new Cursor(display, 2));
 					((SWTFrontend) Emulator.getEmulator()).getInfos().open(this.shell);
 					return;
 				}
-				this.canvas.setCursor(new Cursor(EmulatorScreen.display, 0));
+				this.canvas.setCursor(new Cursor(display, 0));
 				this.canvas.redraw();
 				((SWTFrontend) Emulator.getEmulator()).getInfos().dispose();
 				return;
@@ -1775,9 +1775,9 @@ public final class EmulatorScreen implements
 
 		if (this.pauseState == 0) {
 			// Game not running, show info label
-			gc.setBackground(EmulatorScreen.display.getSystemColor(22));
+			gc.setBackground(display.getSystemColor(22));
 			gc.fillRectangle(0, 0, size.width, size.height);
-			gc.setForeground(EmulatorScreen.display.getSystemColor(21));
+			gc.setForeground(display.getSystemColor(21));
 			gc.setFont(f);
 			gc.drawText(Emulator.getInfoString(), size.width >> 3, size.height >> 3, true);
 			return;
@@ -1791,7 +1791,7 @@ public final class EmulatorScreen implements
 			try {
 				// Fill background
 				if (screenX > 0 || screenY > 0) {
-					gc.setBackground(EmulatorScreen.display.getSystemColor(SWT.COLOR_BLACK));
+					gc.setBackground(display.getSystemColor(SWT.COLOR_BLACK));
 					gc.fillRectangle(0, 0, size.width, size.height);
 				}
 				// Apply transform
@@ -1823,7 +1823,7 @@ public final class EmulatorScreen implements
 		if (this.infosEnabled && (this.mouseXPress != this.mouseXRelease || this.mouseYPress != this.mouseYRelease)) {
 			try {
 				OS_SetROP2(gc, 7);
-				gc.setForeground(EmulatorScreen.display.getSystemColor(1));
+				gc.setForeground(display.getSystemColor(1));
 				gc.drawRectangle(this.mouseXPress, this.mouseYPress, this.mouseXRelease - this.mouseXPress, this.mouseYRelease - this.mouseYPress);
 				OS_SetROP2(gc, 13);
 			} catch (Throwable ignored) {
@@ -2538,8 +2538,8 @@ public final class EmulatorScreen implements
 		shell.setLocation(clientArea.x + (clientArea.width - size.x) / 2, clientArea.y + (clientArea.height - size.y) / 2);
 		shell.open();
 		while (!shell.isDisposed()) {
-			if (!EmulatorScreen.display.readAndDispatch()) {
-				EmulatorScreen.display.sleep();
+			if (!display.readAndDispatch()) {
+				display.sleep();
 			}
 		}
 
@@ -2650,14 +2650,14 @@ public final class EmulatorScreen implements
 					while (System.currentTimeMillis() - this.aClass93_1196.vibraStart < this.aClass93_1196.vibra && !this.stop) {
 						if (EmulatorScreen.method566(this.aClass93_1196) != 2) {
 							if (EmulatorScreen.this.shell.isDisposed()) return;
-							SWTFrontend.syncExec(shellPosition);
+							display.syncExec(shellPosition);
 							this.anInt1197 = shellPosition.anInt1478;
 							this.anInt1198 = shellPosition.anInt1481;
 							if (this.anInt1193++ > 10) {
-								SWTFrontend.asyncExec(this.aClass93_1196.new ShellPosition(aClass93_1196, this.anInt1197 + this.aRandom1195.nextInt() % 5, this.anInt1198 + this.aRandom1195.nextInt() % 5, false));
+								display.asyncExec(this.aClass93_1196.new ShellPosition(aClass93_1196, this.anInt1197 + this.aRandom1195.nextInt() % 5, this.anInt1198 + this.aRandom1195.nextInt() % 5, false));
 								this.anInt1193 = 0;
 							}
-							SWTFrontend.asyncExec(this.aClass93_1196.new ShellPosition(aClass93_1196, this.anInt1197, this.anInt1198, false));
+							display.asyncExec(this.aClass93_1196.new ShellPosition(aClass93_1196, this.anInt1197, this.anInt1198, false));
 						}
 						Thread.sleep(1L);
 					}

--- a/src/main/emulator/ui/swt/EmulatorScreen.java
+++ b/src/main/emulator/ui/swt/EmulatorScreen.java
@@ -189,7 +189,7 @@ public final class EmulatorScreen implements
 
 	public EmulatorScreen(final int n, final int n2) {
 		this.pauseStateStrings = new String[]{UILocale.get("MAIN_INFO_BAR_UNLOADED", "UNLOADED"), UILocale.get("MAIN_INFO_BAR_RUNNING", "RUNNING"), UILocale.get("MAIN_INFO_BAR_PAUSED", "PAUSED")};
-		EmulatorScreen.display = EmulatorImpl.getDisplay();
+		EmulatorScreen.display = SWTFrontend.getDisplay();
 		this.initShell();
 		this.initScreenBuffer(startWidth = n, startHeight = n2);
 		this.updatePauseState();
@@ -291,7 +291,7 @@ public final class EmulatorScreen implements
 
 	// these two must be COMPLETELY separate paths, but we have what we have.
 
-	public void startWithMidlet(){
+	public void startWithMidlet() {
 		start(true);
 	}
 
@@ -328,8 +328,8 @@ public final class EmulatorScreen implements
 		}
 		this.shell.setLocation(EmulatorScreen.locX, EmulatorScreen.locY);
 //		EmulatorImpl.asyncExec(new WindowOpen(this, 0));
-		EmulatorImpl.asyncExec(new WindowOpen(this, 1));
-		EmulatorImpl.asyncExec(new WindowOpen(this, 2));
+		SWTFrontend.asyncExec(new WindowOpen(this, 1));
+		SWTFrontend.asyncExec(new WindowOpen(this, 2));
 
 		if (midletLoaded) {
 			String s = Emulator.getEmulator().getAppProperty("Nokia-UI-Enhancement");
@@ -765,10 +765,10 @@ public final class EmulatorScreen implements
 		if (Settings.asyncFlush) {
 			if (paintPending) return;
 			paintPending = true;
-			EmulatorImpl.asyncExec(this);
+			SWTFrontend.asyncExec(this);
 			return;
 		}
-		EmulatorImpl.syncExec(this);
+		SWTFrontend.syncExec(this);
 	}
 
 	public int getWidth() {
@@ -781,12 +781,12 @@ public final class EmulatorScreen implements
 
 	public void setCommandLeft(final String text) {
 		this.leftCmdText = text;
-		EmulatorImpl.syncExec(new Class41(this));
+		SWTFrontend.syncExec(new Class41(this));
 	}
 
 	public void setCommandRight(final String text) {
 		this.rightCmdText = text;
-		EmulatorImpl.syncExec(new Class40(this));
+		SWTFrontend.syncExec(new Class40(this));
 	}
 
 
@@ -1437,7 +1437,7 @@ public final class EmulatorScreen implements
 					public void run() {
 						Updater.checkUpdate();
 						if (Updater.state == Updater.STATE_UPDATE_AVAILABLE) {
-							EmulatorImpl.asyncExec(new Runnable() {
+							SWTFrontend.asyncExec(new Runnable() {
 								public void run() {
 									showUpdateDialog(1);
 								}
@@ -1445,7 +1445,7 @@ public final class EmulatorScreen implements
 							return;
 						}
 						if (Updater.state == Updater.STATE_UP_TO_DATE) {
-							EmulatorImpl.syncExec(new Runnable() {
+							SWTFrontend.syncExec(new Runnable() {
 								public void run() {
 									showMessage(UILocale.get("UPDATE_ALREADY_LATEST_TEXT", "You already have the latest version of KEmulator."));
 								}
@@ -1476,23 +1476,23 @@ public final class EmulatorScreen implements
 				return;
 			}
 			if (menuItem == this.keypadMenuItem) {
-				if (((EmulatorImpl) Emulator.getEmulator()).getKeyPad().method834()) {
-					((EmulatorImpl) Emulator.getEmulator()).getKeyPad().dipose();
+				if (((SWTFrontend) Emulator.getEmulator()).getKeyPad().method834()) {
+					((SWTFrontend) Emulator.getEmulator()).getKeyPad().dipose();
 					return;
 				}
-				((EmulatorImpl) Emulator.getEmulator()).getKeyPad().method835(this.shell);
+				((SWTFrontend) Emulator.getEmulator()).getKeyPad().method835(this.shell);
 				return;
 			}
 			if (menuItem == this.infosMenuItem) {
 				this.infosEnabled = this.infosMenuItem.getSelection();
 				if (this.infosEnabled) {
 					this.canvas.setCursor(new Cursor(EmulatorScreen.display, 2));
-					((EmulatorImpl) Emulator.getEmulator()).getInfos().open(this.shell);
+					((SWTFrontend) Emulator.getEmulator()).getInfos().open(this.shell);
 					return;
 				}
 				this.canvas.setCursor(new Cursor(EmulatorScreen.display, 0));
 				this.canvas.redraw();
-				((EmulatorImpl) Emulator.getEmulator()).getInfos().dispose();
+				((SWTFrontend) Emulator.getEmulator()).getInfos().dispose();
 				return;
 			}
 			if (menuItem == this.rotateScreenMenuItem) {
@@ -1549,11 +1549,11 @@ public final class EmulatorScreen implements
 			}
 			if (menuItem == m3gViewMenuItem) {
 				try {
-					if (((EmulatorImpl) Emulator.getEmulator()).getM3GView().method494()) {
-						((EmulatorImpl) Emulator.getEmulator()).getM3GView().close();
+					if (((SWTFrontend) Emulator.getEmulator()).getM3GView().method494()) {
+						((SWTFrontend) Emulator.getEmulator()).getM3GView().close();
 						return;
 					}
-					((EmulatorImpl) Emulator.getEmulator()).getM3GView().method226();
+					((SWTFrontend) Emulator.getEmulator()).getM3GView().method226();
 				} catch (Throwable e) {
 					e.printStackTrace();
 				}
@@ -1564,42 +1564,42 @@ public final class EmulatorScreen implements
 				return;
 			}
 			if (menuItem == this.watchesMenuItem) {
-				if (((EmulatorImpl) Emulator.getEmulator()).getClassWatcher().isVisible()) {
-					((EmulatorImpl) Emulator.getEmulator()).getClassWatcher().dispose();
+				if (((SWTFrontend) Emulator.getEmulator()).getClassWatcher().isVisible()) {
+					((SWTFrontend) Emulator.getEmulator()).getClassWatcher().dispose();
 					return;
 				}
-				((EmulatorImpl) Emulator.getEmulator()).getClassWatcher().open(this.shell);
+				((SWTFrontend) Emulator.getEmulator()).getClassWatcher().open(this.shell);
 				return;
 			}
 			if (menuItem == this.profilerMenuItem) {
-				if (((EmulatorImpl) Emulator.getEmulator()).getProfiler().isVisible()) {
-					((EmulatorImpl) Emulator.getEmulator()).getProfiler().dispose();
+				if (((SWTFrontend) Emulator.getEmulator()).getProfiler().isVisible()) {
+					((SWTFrontend) Emulator.getEmulator()).getProfiler().dispose();
 					return;
 				}
-				((EmulatorImpl) Emulator.getEmulator()).getProfiler().open(this.shell);
+				((SWTFrontend) Emulator.getEmulator()).getProfiler().open(this.shell);
 				return;
 			}
 			if (menuItem == this.methodsMenuItem) {
-				if (((EmulatorImpl) Emulator.getEmulator()).getMethods().method438()) {
-					((EmulatorImpl) Emulator.getEmulator()).getMethods().dispose();
+				if (((SWTFrontend) Emulator.getEmulator()).getMethods().method438()) {
+					((SWTFrontend) Emulator.getEmulator()).getMethods().dispose();
 					return;
 				}
-				((EmulatorImpl) Emulator.getEmulator()).getMethods().method436();
+				((SWTFrontend) Emulator.getEmulator()).getMethods().method436();
 				return;
 			}
 			if (menuItem == this.memoryViewMenuItem) {
-				if (((EmulatorImpl) Emulator.getEmulator()).getMemory().isShown()) {
-					((EmulatorImpl) Emulator.getEmulator()).getMemory().dispose();
+				if (((SWTFrontend) Emulator.getEmulator()).getMemory().isShown()) {
+					((SWTFrontend) Emulator.getEmulator()).getMemory().dispose();
 					return;
 				}
-				((EmulatorImpl) Emulator.getEmulator()).getMemory().open();
+				((SWTFrontend) Emulator.getEmulator()).getMemory().open();
 			}
 			if (menuItem == this.mediaViewMenuItem) {
-				if (((EmulatorImpl) Emulator.getEmulator()).getMedia().isShown()) {
-					((EmulatorImpl) Emulator.getEmulator()).getMedia().dispose();
+				if (((SWTFrontend) Emulator.getEmulator()).getMedia().isShown()) {
+					((SWTFrontend) Emulator.getEmulator()).getMedia().dispose();
 					return;
 				}
-				((EmulatorImpl) Emulator.getEmulator()).getMedia().open();
+				((SWTFrontend) Emulator.getEmulator()).getMedia().open();
 			}
 		} else if (parent == menuResize) {
 			if (menuItem == centerOnScreenMenuItem) {
@@ -1719,7 +1719,7 @@ public final class EmulatorScreen implements
         (int)(this.mouseYPress / this.zoom) + "," + (int)((this.mouseXRelease - this.mouseXPress) / this.zoom) +
         "," + (int)((this.mouseYRelease - this.mouseYPress) / this.zoom) + ")";
         */
-		((EmulatorImpl) Emulator.getEmulator()).getInfos().setText(this.aString1008);
+		((SWTFrontend) Emulator.getEmulator()).getInfos().setText(this.aString1008);
 	}
 
 	private void method588() {
@@ -1902,7 +1902,7 @@ public final class EmulatorScreen implements
 						c.layout();
 					}
 				}
-				updateTitle();
+				updateTitleInternal();
 				canvas.layout();
 				lastDisplayable._swtShown();
 			}
@@ -1910,6 +1910,10 @@ public final class EmulatorScreen implements
 	}
 
 	public void updateTitle() {
+		display.syncExec(this::updateTitleInternal);
+	}
+
+	private void updateTitleInternal() {
 		String title = null;
 		if (lastDisplayable == null ||
 				(title = lastDisplayable.getTitle()) == null ||
@@ -2035,7 +2039,7 @@ public final class EmulatorScreen implements
 	private void onKeyUp(int n, boolean screen) {
 		n = key(n);
 		if (!screen) {
-			((EmulatorImpl) Emulator.getEmulator()).getM3GView().keyReleased(n);
+			((SWTFrontend) Emulator.getEmulator()).getM3GView().keyReleased(n);
 			return;
 		}
 		if (n <= 0 || this.pauseState == 0 || Settings.playingRecordedKeys) {
@@ -2351,11 +2355,11 @@ public final class EmulatorScreen implements
 			}
 		}
 		final Shell method330;
-		if (((EmulatorImpl) Emulator.getEmulator()).getInfos().isShown() && !(method330 = ((EmulatorImpl) Emulator.getEmulator()).getInfos().getShell()).isDisposed()) {
+		if (((SWTFrontend) Emulator.getEmulator()).getInfos().isShown() && !(method330 = ((SWTFrontend) Emulator.getEmulator()).getInfos().getShell()).isDisposed()) {
 			method330.setLocation(this.shell.getLocation().x + this.shell.getSize().x, this.shell.getLocation().y);
 		}
 		final Shell method331;
-		if (((EmulatorImpl) Emulator.getEmulator()).getKeyPad().method834() && !(method331 = ((EmulatorImpl) Emulator.getEmulator()).getKeyPad().method833()).isDisposed()) {
+		if (((SWTFrontend) Emulator.getEmulator()).getKeyPad().method834() && !(method331 = ((SWTFrontend) Emulator.getEmulator()).getKeyPad().method833()).isDisposed()) {
 			method331.setLocation(this.shell.getLocation().x + this.shell.getSize().x, this.shell.getLocation().y);
 		}
 	}
@@ -2490,13 +2494,13 @@ public final class EmulatorScreen implements
 	}
 
 	public void appStarted(boolean first) {
-		if (first) EmulatorImpl.asyncExec(new WindowOpen(this, 0));
+		if (first) SWTFrontend.asyncExec(new WindowOpen(this, 0));
 	}
 
 	public int showMidletChoice(Vector<String> midletKeys) {
 		dialogSelection = -1;
 
-		Shell shell = new Shell(EmulatorImpl.getDisplay(), SWT.DIALOG_TRIM);
+		Shell shell = new Shell(SWTFrontend.getDisplay(), SWT.DIALOG_TRIM);
 		shell.setSize(300, 400);
 		shell.setText(UILocale.get("START_MIDLET_CHOICE_TITLE", "Choose MIDlet to run"));
 		shell.setLayout(new GridLayout(1, false));
@@ -2524,7 +2528,7 @@ public final class EmulatorScreen implements
 			TableItem t = new TableItem(table, SWT.NONE);
 			t.setText(0, p[0].trim());
 			try {
-				t.setImage(0, new Image(EmulatorImpl.getDisplay(), CustomJarResources.getResourceAsStream(p[1].trim())));
+				t.setImage(0, new Image(SWTFrontend.getDisplay(), CustomJarResources.getResourceAsStream(p[1].trim())));
 			} catch (Exception ignored) {
 			}
 		}
@@ -2575,7 +2579,7 @@ public final class EmulatorScreen implements
 			MessageBox messageBox = new MessageBox(shell, SWT.YES | SWT.NO);
 			messageBox.setMessage(message);
 			messageBox.setText(UILocale.get("SECURITY_ALERT_TITLE", "Security"));
-			ok[0] = messageBox.open()== SWT.YES;
+			ok[0] = messageBox.open() == SWT.YES;
 		});
 		return ok[0];
 	}
@@ -2646,14 +2650,14 @@ public final class EmulatorScreen implements
 					while (System.currentTimeMillis() - this.aClass93_1196.vibraStart < this.aClass93_1196.vibra && !this.stop) {
 						if (EmulatorScreen.method566(this.aClass93_1196) != 2) {
 							if (EmulatorScreen.this.shell.isDisposed()) return;
-							EmulatorImpl.syncExec(shellPosition);
+							SWTFrontend.syncExec(shellPosition);
 							this.anInt1197 = shellPosition.anInt1478;
 							this.anInt1198 = shellPosition.anInt1481;
 							if (this.anInt1193++ > 10) {
-								EmulatorImpl.asyncExec(this.aClass93_1196.new ShellPosition(aClass93_1196, this.anInt1197 + this.aRandom1195.nextInt() % 5, this.anInt1198 + this.aRandom1195.nextInt() % 5, false));
+								SWTFrontend.asyncExec(this.aClass93_1196.new ShellPosition(aClass93_1196, this.anInt1197 + this.aRandom1195.nextInt() % 5, this.anInt1198 + this.aRandom1195.nextInt() % 5, false));
 								this.anInt1193 = 0;
 							}
-							EmulatorImpl.asyncExec(this.aClass93_1196.new ShellPosition(aClass93_1196, this.anInt1197, this.anInt1198, false));
+							SWTFrontend.asyncExec(this.aClass93_1196.new ShellPosition(aClass93_1196, this.anInt1197, this.anInt1198, false));
 						}
 						Thread.sleep(1L);
 					}
@@ -2678,7 +2682,7 @@ public final class EmulatorScreen implements
 		public void run() {
 			switch (this.target) {
 				case 0: {
-					MemoryView m = ((EmulatorImpl) Emulator.getEmulator()).getMemory();
+					MemoryView m = ((SWTFrontend) Emulator.getEmulator()).getMemory();
 					if (Settings.showMemViewFrame && !m.isShown()) {
 						this.screen.memoryViewMenuItem.setSelection(true);
 						m.open();
@@ -2699,7 +2703,7 @@ public final class EmulatorScreen implements
 						infosEnabled = true;
 						this.screen.infosMenuItem.setSelection(true);
 						EmulatorScreen.getCanvas(this.screen).setCursor(new Cursor(EmulatorScreen.method564(), 2));
-						((EmulatorImpl) Emulator.getEmulator()).getInfos().open(EmulatorScreen.method561(this.screen));
+						((SWTFrontend) Emulator.getEmulator()).getInfos().open(EmulatorScreen.method561(this.screen));
 						break;
 					}
 					break;

--- a/src/main/emulator/ui/swt/EmulatorScreen.java
+++ b/src/main/emulator/ui/swt/EmulatorScreen.java
@@ -289,7 +289,17 @@ public final class EmulatorScreen implements
 		}
 	}
 
-	public void start(final boolean midletLoaded) {
+	// these two must be COMPLETELY separate paths, but we have what we have.
+
+	public void startWithMidlet(){
+		start(true);
+	}
+
+	public void startEmpty() {
+		start(false);
+	}
+
+	void start(final boolean midletLoaded) {
 		this.pauseState = (midletLoaded ? 1 : 0);
 		this.updatePauseState(); // updated before canvas rect because it checks for pauseState inside
 		try {
@@ -2557,6 +2567,28 @@ public final class EmulatorScreen implements
 		}
 
 		return dialogSelection;
+	}
+
+	public boolean showSecurityDialog(final String message) {
+		final boolean[] ok = new boolean[1];
+		shell.getDisplay().syncExec(() -> {
+			MessageBox messageBox = new MessageBox(shell, SWT.YES | SWT.NO);
+			messageBox.setMessage(message);
+			messageBox.setText(UILocale.get("SECURITY_ALERT_TITLE", "Security"));
+			ok[0] = messageBox.open()== SWT.YES;
+		});
+		return ok[0];
+	}
+
+	public String showIMEIDialog() {
+		InputDialog imeiDialog = new InputDialog(shell);
+		shell.getDisplay().syncExec(() -> {
+			imeiDialog.setMessage("Application asks for IMEI");
+			imeiDialog.setInput("0000000000000000");
+			imeiDialog.setText(UILocale.get("SECURITY_ALERT_TITLE", "Security"));
+			imeiDialog.open();
+		});
+		return imeiDialog.getInput();
 	}
 
 	public boolean getTouchEnabled() {

--- a/src/main/emulator/ui/swt/KeyPad.java
+++ b/src/main/emulator/ui/swt/KeyPad.java
@@ -185,13 +185,13 @@ public final class KeyPad implements ControlListener, DisposeListener {
 
 	private static void method832(final int n) {
 		try {
-			((EmulatorImpl) Emulator.getEmulator()).getEmulatorScreen().handleKeyPress(Integer.parseInt(KeyMapping.deviceKeycodes[n]));
+			((EmulatorScreen) Emulator.getEmulator().getScreen()).handleKeyPress(Integer.parseInt(KeyMapping.deviceKeycodes[n]));
 		} catch (Exception ignored) {}
 	}
 
 	private static void method839(final int n) {
 		try {
-			((EmulatorImpl) Emulator.getEmulator()).getEmulatorScreen().handleKeyRelease(Integer.parseInt(KeyMapping.deviceKeycodes[n]));
+			((EmulatorScreen) Emulator.getEmulator().getScreen()).handleKeyRelease(Integer.parseInt(KeyMapping.deviceKeycodes[n]));
 		} catch (Exception ignored) {}
 	}
 

--- a/src/main/emulator/ui/swt/Log.java
+++ b/src/main/emulator/ui/swt/Log.java
@@ -174,7 +174,7 @@ public final class Log implements ILogStream, ControlListener, DisposeListener, 
 		try {
 			while (true) {
 				if (printQueue.length() > 0) {
-					EmulatorImpl.syncExec(new Textout(this));
+					SWTFrontend.syncExec(new Textout(this));
 				} else {
 					synchronized (printQueue) {
 						printQueue.wait();

--- a/src/main/emulator/ui/swt/M3GViewUI.java
+++ b/src/main/emulator/ui/swt/M3GViewUI.java
@@ -855,7 +855,7 @@ public final class M3GViewUI implements MouseMoveListener, DisposeListener, KeyL
 				if (aClass90_830.canvas.isDisposed()) {
 					return;
 				}
-				EmulatorImpl.syncExec(new Class10(this));
+				SWTFrontend.syncExec(new Class10(this));
 				try {
 					Thread.sleep(10L);
 				} catch (Exception ignored) {}

--- a/src/main/emulator/ui/swt/MediaView.java
+++ b/src/main/emulator/ui/swt/MediaView.java
@@ -30,7 +30,7 @@ import java.util.Vector;
 public class MediaView extends SelectionAdapter implements DisposeListener, SelectionListener, Runnable {
 
 	private Shell shell;
-	private final Display display = EmulatorImpl.getDisplay();
+	private final Display display = SWTFrontend.getDisplay();
 	private final Memory memoryMgr = Memory.getInstance();
 	private Button resumeBtn;
 	private Button pauseBtn;
@@ -295,7 +295,7 @@ public class MediaView extends SelectionAdapter implements DisposeListener, Sele
 		try {
 			Thread.sleep(1000);
 			do {
-				EmulatorImpl.syncExec(this::updateAll);
+				SWTFrontend.syncExec(this::updateAll);
 				Thread.sleep(1000);
 			} while (visible && !this.shell.isDisposed());
 		} catch (InterruptedException e) {

--- a/src/main/emulator/ui/swt/MediaView.java
+++ b/src/main/emulator/ui/swt/MediaView.java
@@ -295,7 +295,7 @@ public class MediaView extends SelectionAdapter implements DisposeListener, Sele
 		try {
 			Thread.sleep(1000);
 			do {
-				SWTFrontend.syncExec(this::updateAll);
+				display.syncExec(this::updateAll);
 				Thread.sleep(1000);
 			} while (visible && !this.shell.isDisposed());
 		} catch (InterruptedException e) {

--- a/src/main/emulator/ui/swt/MemoryView.java
+++ b/src/main/emulator/ui/swt/MemoryView.java
@@ -31,7 +31,7 @@ public final class MemoryView implements DisposeListener {
 	private CLabel objectsSizeLbl;
 	private CLabel totalmemLbl;
 	private CLabel maxmemLbl;
-	private final Display display = EmulatorImpl.getDisplay();
+	private final Display display = SWTFrontend.getDisplay();
 	public final Memory memoryMgr = Memory.getInstance();
 	private boolean visible;
 	private Composite aComposite1098;
@@ -764,7 +764,7 @@ public final class MemoryView implements DisposeListener {
 				try {
 					if (System.currentTimeMillis() - this.currentMillis > this.updateInterval && !mv.isUpdating()) {
 						this.mv.updateModel();
-						EmulatorImpl.syncExec(mv::updateView);
+						SWTFrontend.syncExec(mv::updateView);
 
 						this.currentMillis = System.currentTimeMillis();
 					}

--- a/src/main/emulator/ui/swt/MessageConsole.java
+++ b/src/main/emulator/ui/swt/MessageConsole.java
@@ -86,7 +86,7 @@ public final class MessageConsole implements IMessage, ControlListener, DisposeL
 			MessageConsole.aString871 = sb.append(payloadText).toString();
 		}
 		Emulator.getEmulator().getLogStream().println(MessageConsole.aString871);
-		EmulatorImpl.syncExec(new Textout(this));
+		SWTFrontend.syncExec(new Textout(this));
 	}
 
 	public final boolean method479() {

--- a/src/main/emulator/ui/swt/Property.java
+++ b/src/main/emulator/ui/swt/Property.java
@@ -1926,7 +1926,7 @@ public final class Property implements IProperty, SelectionListener {
 		if (this.controllerCombo == null || this.controllerCombo.isDisposed()) {
 			return false;
 		}
-		EmulatorImpl.asyncExec(new Class193(this));
+		SWTFrontend.asyncExec(new Class193(this));
 		return true;
 	}
 

--- a/src/main/emulator/ui/swt/SWTFrontend.java
+++ b/src/main/emulator/ui/swt/SWTFrontend.java
@@ -19,7 +19,7 @@ import java.util.Hashtable;
 import java.util.Properties;
 import java.util.Vector;
 
-public final class EmulatorImpl implements IEmulator {
+public final class SWTFrontend implements IEmulatorFrontend {
 	private static Display display;
 	private Vector plugins;
 	private int screenDepth;
@@ -38,11 +38,11 @@ public final class EmulatorImpl implements IEmulator {
 	public Properties midletProps;
 	private static Hashtable<String, FontSWT> swtFontsCache = new Hashtable<String, FontSWT>();
 
-	public EmulatorImpl() {
+	public SWTFrontend() {
 		super();
-		EmulatorImpl.display = new Display();
+		display = new Display();
 		this.plugins = new Vector();
-		this.screenDepth = EmulatorImpl.display.getDepth();
+		this.screenDepth = SWTFrontend.display.getDepth();
 		this.iproperty = new Property();
 		this.ilogstream = new Log();
 		this.sms = new MessageConsole();
@@ -53,25 +53,25 @@ public final class EmulatorImpl implements IEmulator {
 		this.methods = new Methods();
 	}
 
-	public static void dispose() {
-		if (!EmulatorImpl.display.isDisposed()) {
-			EmulatorImpl.display.dispose();
+	public void dispose() {
+		if (!display.isDisposed()) {
+			display.dispose();
 		}
 	}
 
 	public static Display getDisplay() {
-		return EmulatorImpl.display;
+		return display;
 	}
 
 	public static void syncExec(final Runnable runnable) {
-		if (!EmulatorImpl.display.isDisposed()) {
-			EmulatorImpl.display.syncExec(runnable);
+		if (!display.isDisposed()) {
+			display.syncExec(runnable);
 		}
 	}
 
 	public static void asyncExec(final Runnable runnable) {
-		if (!EmulatorImpl.display.isDisposed()) {
-			EmulatorImpl.display.asyncExec(runnable);
+		if (!display.isDisposed()) {
+			display.asyncExec(runnable);
 		}
 	}
 

--- a/src/main/emulator/ui/swt/Watcher.java
+++ b/src/main/emulator/ui/swt/Watcher.java
@@ -173,7 +173,7 @@ public final class Watcher extends SelectionAdapter implements Runnable, Dispose
 		final Instance c = getWatched();
 		if (item.getParentItem() == null) {
 			this.method301(c, (Field) c.getFields().get(item.getParent().indexOf(item)), item);
-			EmulatorImpl.asyncExec(this);
+			SWTFrontend.asyncExec(this);
 			return;
 		}
 		TreeItem parentItem = item;
@@ -197,7 +197,7 @@ public final class Watcher extends SelectionAdapter implements Runnable, Dispose
 			s = s2.substring(0, s2.length() - 2);
 		}
 		method305(o, s2, item);
-		EmulatorImpl.asyncExec(this);
+		SWTFrontend.asyncExec(this);
 	}
 
 	public void treeCollapsed(TreeEvent var1) {
@@ -316,9 +316,9 @@ public final class Watcher extends SelectionAdapter implements Runnable, Dispose
 		updateColumnSizes();
 		disposed = false;
 		visible = true;
-		EmulatorImpl.asyncExec(this);
+		SWTFrontend.asyncExec(this);
 		Watcher.activeWatchers.addElement(this);
-		Display display = EmulatorImpl.getDisplay();
+		Display display = SWTFrontend.getDisplay();
 		while (!this.shell.isDisposed()) {
 			if (!display.readAndDispatch()) {
 				display.sleep();
@@ -584,7 +584,7 @@ public final class Watcher extends SelectionAdapter implements Runnable, Dispose
 
 	public void widgetSelected(final SelectionEvent se) {
 		if (se.widget == hexDecSwitch) {
-			EmulatorImpl.asyncExec(this);
+			SWTFrontend.asyncExec(this);
 		} else if (se.widget == exportBtn) {
 			new Thread(this::exportValues).start();
 		}
@@ -592,7 +592,7 @@ public final class Watcher extends SelectionAdapter implements Runnable, Dispose
 
 	private void onFilterTextModify(ModifyEvent modifyEvent) {
 		updateContent();
-		EmulatorImpl.asyncExec(this);
+		SWTFrontend.asyncExec(this);
 	}
 
 	private boolean createClassCombo() {

--- a/src/midp/javax/microedition/lcdui/Displayable.java
+++ b/src/midp/javax/microedition/lcdui/Displayable.java
@@ -5,7 +5,7 @@ import emulator.debug.Profiler;
 import emulator.lcdui.LCDUIUtils;
 import emulator.media.capture.CapturePlayerImpl;
 import emulator.ui.IScreen;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import emulator.ui.swt.EmulatorScreen;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
@@ -276,7 +276,7 @@ public class Displayable {
 	public void setTitle(final String title) {
 		this.title = title;
 		if (isShown()) {
-			syncExec(() -> Emulator.getEmulator().getScreen().updateTitle());
+			Emulator.getEmulator().getScreen().updateTitle();
 		}
 	}
 
@@ -473,16 +473,16 @@ public class Displayable {
 	}
 
 	static void syncExec(Runnable r) {
-		EmulatorImpl.syncExec(r);
+		SWTFrontend.syncExec(r);
 	}
 
 	static void asyncExec(Runnable r) {
-		EmulatorImpl.asyncExec(r);
+		SWTFrontend.asyncExec(r);
 	}
 
 	static void safeSyncExec(Runnable r) {
 		try {
-			EmulatorImpl.syncExec(r);
+			SWTFrontend.syncExec(r);
 		} catch (SWTException e) {
 			Throwable cause = e.getCause();
 			if (cause instanceof RuntimeException) {

--- a/src/midp/javax/microedition/lcdui/Displayable.java
+++ b/src/midp/javax/microedition/lcdui/Displayable.java
@@ -2,7 +2,6 @@ package javax.microedition.lcdui;
 
 import emulator.*;
 import emulator.debug.Profiler;
-import emulator.graphics2D.swt.FontSWT;
 import emulator.lcdui.LCDUIUtils;
 import emulator.media.capture.CapturePlayerImpl;
 import emulator.ui.IScreen;

--- a/src/midp/javax/microedition/lcdui/Displayable.java
+++ b/src/midp/javax/microedition/lcdui/Displayable.java
@@ -276,11 +276,7 @@ public class Displayable {
 	public void setTitle(final String title) {
 		this.title = title;
 		if (isShown()) {
-			syncExec(new Runnable() {
-				public void run() {
-					((EmulatorScreen) Emulator.getEmulator().getScreen()).updateTitle();
-				}
-			});
+			syncExec(() -> Emulator.getEmulator().getScreen().updateTitle());
 		}
 	}
 

--- a/src/midp/javax/microedition/lcdui/Font.java
+++ b/src/midp/javax/microedition/lcdui/Font.java
@@ -4,7 +4,7 @@ import emulator.Emulator;
 import emulator.Settings;
 import emulator.graphics2D.IFont;
 import emulator.graphics2D.swt.FontSWT;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import emulator.ui.swt.EmulatorScreen;
 
 public class Font {
@@ -146,7 +146,7 @@ public class Font {
 			return ((FontSWT) font.getImpl()).getSWTFont();
 		} else {
 			float zoom = (autoScale ? ((EmulatorScreen) Emulator.getEmulator().getScreen()).getZoom() : 1f) * 0.68f;
-			return new org.eclipse.swt.graphics.Font(EmulatorImpl.getDisplay(),
+			return new org.eclipse.swt.graphics.Font(SWTFrontend.getDisplay(),
 					Emulator.getEmulator().getProperty().getDefaultFontName(),
 					Math.max(2, (int) (font.getHeight() * zoom) - 1),
 					font.getStyle() & ~Font.STYLE_UNDERLINED);
@@ -155,7 +155,7 @@ public class Font {
 
 	static org.eclipse.swt.graphics.Font getDefaultSWTFont(boolean autoScale) {
 		float zoom = (autoScale ? ((EmulatorScreen) Emulator.getEmulator().getScreen()).getZoom() : 1f) * 0.68f;
-		return new org.eclipse.swt.graphics.Font(EmulatorImpl.getDisplay(),
+		return new org.eclipse.swt.graphics.Font(SWTFrontend.getDisplay(),
 				Emulator.getEmulator().getProperty().getDefaultFontName(),
 				Math.max(2, (int) (Screen.font.getHeight() * zoom) - 1), 0);
 	}

--- a/src/midp/javax/microedition/lcdui/Image.java
+++ b/src/midp/javax/microedition/lcdui/Image.java
@@ -5,7 +5,7 @@ import emulator.Emulator;
 import emulator.Settings;
 import emulator.debug.Profiler;
 import emulator.graphics2D.IImage;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -36,7 +36,7 @@ public class Image {
 			return (org.eclipse.swt.graphics.Image) img.imageImpl.getNative();
 		}
 		BufferedImage b = (BufferedImage) img.imageImpl.getNative();
-		return new org.eclipse.swt.graphics.Image(EmulatorImpl.getDisplay(), emulator.graphics2D.c.toSwt(b));
+		return new org.eclipse.swt.graphics.Image(SWTFrontend.getDisplay(), emulator.graphics2D.c.toSwt(b));
 	}
 
 	public void finalize() {

--- a/src/midp/javax/microedition/lcdui/List.java
+++ b/src/midp/javax/microedition/lcdui/List.java
@@ -1,19 +1,13 @@
 package javax.microedition.lcdui;
 
 import emulator.Emulator;
-import emulator.Settings;
 import emulator.UILocale;
-import emulator.graphics2D.swt.FontSWT;
-import emulator.lcdui.LCDUIUtils;
-import emulator.ui.swt.EmulatorImpl;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 

--- a/src/midp/javax/microedition/lcdui/TextBoxLayouter.java
+++ b/src/midp/javax/microedition/lcdui/TextBoxLayouter.java
@@ -16,7 +16,7 @@
 */
 package javax.microedition.lcdui;
 
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
@@ -57,7 +57,7 @@ class TextBoxLayouter
 	{
 		if(staticShell == null)
 		{
-			staticShell = new Shell(EmulatorImpl.getDisplay(), SWT.SYSTEM_MODAL | SWT.VERTICAL);
+			staticShell = new Shell(SWTFrontend.getDisplay(), SWT.SYSTEM_MODAL | SWT.VERTICAL);
 			staticShell.getVerticalBar().setVisible(true);
 		}
 		return staticShell;

--- a/src/midp/javax/microedition/lcdui/TextWrapper.java
+++ b/src/midp/javax/microedition/lcdui/TextWrapper.java
@@ -16,7 +16,7 @@
 */
 package javax.microedition.lcdui;
 
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionListener;
@@ -392,7 +392,7 @@ class TextWrapper
 					bgCol.dispose();
 					bgCol = null;
 				}
-				bgCol = new Color(EmulatorImpl.getDisplay(),
+				bgCol = new Color(SWTFrontend.getDisplay(),
 								  red, green, blue);
 			}
 		});
@@ -576,7 +576,7 @@ class TextWrapper
 					fgCol.dispose();
 					fgCol = null;
 				}
-				fgCol = new Color(EmulatorImpl.getDisplay(),
+				fgCol = new Color(SWTFrontend.getDisplay(),
 								  red, green, blue);
 			}
 		});

--- a/src/midp/javax/microedition/rms/RecordStore.java
+++ b/src/midp/javax/microedition/rms/RecordStore.java
@@ -1,8 +1,8 @@
 package javax.microedition.rms;
 
 import emulator.Emulator;
-import emulator.ui.IEmulator;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.IEmulatorFrontend;
+import emulator.ui.swt.SWTFrontend;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -32,8 +32,8 @@ public class RecordStore {
 
 	static {
 		try {
-			IEmulator em = Emulator.getEmulator();
-			if (((EmulatorImpl) em).midletProps != null) {
+			IEmulatorFrontend em = Emulator.getEmulator();
+			if (((SWTFrontend) em).midletProps != null) {
 				homeRootPath = getRootPath(null, em.getAppProperty("MIDlet-Vendor"), em.getAppProperty("MIDlet-Name"));
 				logln("midlet rms path: " + homeRootPath);
 			}
@@ -227,7 +227,7 @@ public class RecordStore {
 		if (!file.exists() || !file.isDirectory() || !new File(rootPath + "idx").exists()) {
 			throw new RecordStoreNotFoundException(name);
 		}
-		IEmulator e = Emulator.getEmulator();
+		IEmulatorFrontend e = Emulator.getEmulator();
 		return new RecordStore(name, rootPath, vendorName.equals(e.getAppProperty("MIDlet-Vendor")) && suiteName.equals(e.getAppProperty("MIDlet-Name")), true);
 	}
 

--- a/src/nnapi/org/pigler/api/PiglerAPI.java
+++ b/src/nnapi/org/pigler/api/PiglerAPI.java
@@ -3,7 +3,7 @@ package org.pigler.api;
 import com.nokia.mid.ui.SoftNotificationImpl;
 import emulator.Emulator;
 import emulator.graphics2D.awt.ImageAWT;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import emulator.ui.swt.EmulatorScreen;
 import org.eclipse.swt.widgets.Shell;
 
@@ -139,7 +139,7 @@ public class PiglerAPI {
         tapped = true;
         if(launch)
             try {
-                EmulatorImpl.asyncExec(() -> {
+                SWTFrontend.asyncExec(() -> {
                     try {
                         Shell shell = ((EmulatorScreen) Emulator.getEmulator().getScreen()).getShell();
                         shell.setMinimized(false);

--- a/src/oem/com/j_phone/amuse/ACanvas.java
+++ b/src/oem/com/j_phone/amuse/ACanvas.java
@@ -3,13 +3,6 @@ package com.j_phone.amuse;
 import com.jblend.ui.SequenceInterface;
 import com.vodafone.v10.graphics.sprite.SpriteCanvas;
 import emulator.Emulator;
-import emulator.graphics2D.IImage;
-import emulator.ui.IScreen;
-
-import javax.microedition.lcdui.Canvas;
-import javax.microedition.lcdui.Graphics;
-import javax.microedition.lcdui.Image;
-import java.util.ArrayList;
 
 public abstract class ACanvas
 		extends SpriteCanvas

--- a/src/oem/com/j_phone/ui/EnhancedFEPControl.java
+++ b/src/oem/com/j_phone/ui/EnhancedFEPControl.java
@@ -1,7 +1,7 @@
 package com.j_phone.ui;
 
 import emulator.Emulator;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import emulator.ui.swt.EmulatorScreen;
 import emulator.ui.swt.InputDialog;
 
@@ -13,7 +13,7 @@ public final class EnhancedFEPControl {
 	}
 
 	public String getInputText(String paramString, int paramInt1, int paramInt2, boolean paramBoolean) {
-		EmulatorImpl.getDisplay().syncExec(new Runnable() {
+		SWTFrontend.getDisplay().syncExec(new Runnable() {
 			public void run() {
 				inputDialog = new InputDialog(((EmulatorScreen) Emulator.getEmulator().getScreen()).getShell());
 				inputDialog.setInput(paramString);

--- a/src/oem/com/j_phone/ui/FEPControl.java
+++ b/src/oem/com/j_phone/ui/FEPControl.java
@@ -1,7 +1,7 @@
 package com.j_phone.ui;
 
 import emulator.Emulator;
-import emulator.ui.swt.EmulatorImpl;
+import emulator.ui.swt.SWTFrontend;
 import emulator.ui.swt.EmulatorScreen;
 import emulator.ui.swt.InputDialog;
 
@@ -13,7 +13,7 @@ public final class FEPControl {
 	}
 
 	public String getInputText(String text, int inputMode, int length, boolean paramBoolean) {
-		EmulatorImpl.getDisplay().syncExec(new Runnable() {
+		SWTFrontend.getDisplay().syncExec(new Runnable() {
 			public void run() {
 				inputDialog = new InputDialog(((EmulatorScreen) Emulator.getEmulator().getScreen()).getShell());
 				inputDialog.setInput(text);


### PR DESCRIPTION
Depends on #157 (merge it in master, then merge master here)

Related: #98 

Расширяет `IScreen` и переносит часть говна в `EmulatorScreen` так, чтоб код вне `emulator.ui.swt` перестал зависеть от, собственно, интерфейса на swt.

Всё ещё проблемой является задействование синхронизации свт (`SWTFrontend.syncExec` повсюду в коде), но это проблема для отдельного разбирательства. К лцдую на свт будет применена тактика игнорирования вплоть до первого релиза хэдлесса.

Сиё является необходимым для того чтоб я начал писать хэдлесс фронт, который по сути будет второй реализацией `IEmulatorFrontend` и `IScreen`, только вместо свт будет папка с posix fifo.