### PR TITLE
fix Graphics.drawRGB() performance bottleneck

### DIFF
--- a/src/main/emulator/Settings.java
+++ b/src/main/emulator/Settings.java
@@ -6,7 +6,9 @@ import java.util.*;
 
 public final class Settings {
 	// original settings
-	public static int g2d = 1; // swt - 0, awt - 1
+	public static final int AWT = 1;
+	public static final int SWT = 0;
+	public static int g2d = AWT; // swt - 0, awt - 1
 	public static boolean enableVibration;
 	public static boolean enableKeyRepeat;
 	public static boolean ignoreFullScreen;

--- a/src/main/emulator/graphics2D/IImage.java
+++ b/src/main/emulator/graphics2D/IImage.java
@@ -15,6 +15,8 @@ public interface IImage {
 
 	int[] getData();
 
+	boolean gaveDataRefernce();
+
 	void setData(final int[] p0);
 
 	int getRGB(final int x, final int y);

--- a/src/main/emulator/graphics2D/awt/ImageAWT.java
+++ b/src/main/emulator/graphics2D/awt/ImageAWT.java
@@ -24,6 +24,7 @@ public final class ImageAWT implements IImage {
 	private Graphics2DAWT graphics;
 	private Graphics2D g2d;
 	private int[] data;
+	private boolean gaveDataReference;
 
 	public ImageAWT(final byte[] array) throws IOException {
 		super();
@@ -96,10 +97,12 @@ public final class ImageAWT implements IImage {
 	public final int[] getData() {
 		try {
 			final int[] data = getInternalData();
+			gaveDataReference = true;
 			if (!img.getColorModel().hasAlpha()) {
 				for (int i = data.length - 1; i >= 0; --i) {
 					data[i] |= 0xFF000000;
 				}
+				gaveDataReference = false;
 			}
 			return data;
 		} catch (ClassCastException e) {
@@ -113,9 +116,12 @@ public final class ImageAWT implements IImage {
 						(data[i++] & 0xFF);
 //            	intdata[i] = data[i];
 			}
+			gaveDataReference = false;
 			return intdata;
 		}
 	}
+
+	public final boolean gaveDataRefernce() {return this.gaveDataReference;}
 
 	public final void setData(final int[] array) {
 		final int[] data = getInternalData();

--- a/src/main/emulator/graphics2D/b.java
+++ b/src/main/emulator/graphics2D/b.java
@@ -50,36 +50,34 @@ public final class b {
 		image.setData(data);
 	}
 
-	public static IImage method163(final int[] array, final boolean b, int n, final int n2, final int n3, final int n4) {
-		method161(n3, n4);
+	public static IImage method163(final int[] rgbData, final boolean processAlpha, int offset, final int scanlength, final int width, final int height) {
+		method161(width, height);
 		int[] data = null;
-		Label_0039:
-		{
-			int[] array2;
-			if (Settings.g2d == 0) {
-				array2 = emulator.graphics2D.b.anIntArray352;
-			} else {
-				if (Settings.g2d != 1) {
-					break Label_0039;
-				}
-				array2 = emulator.graphics2D.b.anIImage351.getData();
-			}
+		int[] array2;
+		if (Settings.g2d == Settings.SWT) {
+			array2 = b.anIntArray352;
+			data = array2;
+		} else if (Settings.g2d == Settings.AWT){
+			array2 = b.anIImage351.getData();
 			data = array2;
 		}
 		int n5 = 0;
-		for (int i = 0; i < n4; ++i) {
-			System.arraycopy(array, n, data, n5, n3);
-			if (!b) {
-				for (int j = 0; j < n3; ++j) {
+		for (int i = 0; i < height; ++i) {
+			System.arraycopy(rgbData, offset, data, n5, width);
+			if (!processAlpha) {
+				for (int j = 0; j < width; ++j) {
 					final int n6 = n5 + j;
 					data[n6] |= 0xFF000000;
 				}
 			}
-			n5 += emulator.graphics2D.b.anIImage351.getWidth();
-			n += n2;
+			n5 += b.anIImage351.getWidth();
+			offset += scanlength;
 		}
-		emulator.graphics2D.b.anIImage351.setData(data);
-		return emulator.graphics2D.b.anIImage351;
+		if (b.anIImage351.gaveDataRefernce()) {
+			return b.anIImage351;
+		}
+		b.anIImage351.setData(data);
+		return b.anIImage351;
 	}
 
 	public static IImage method164(final short[] array, final boolean b, int n, final int n2, final int n3, final int n4) {

--- a/src/main/emulator/graphics2D/swt/ImageSWT.java
+++ b/src/main/emulator/graphics2D/swt/ImageSWT.java
@@ -200,6 +200,10 @@ public final class ImageSWT implements IImage {
 		}
 		return this.rgb;
 	}
+	
+	public boolean gaveDataRefernce() {
+		return false;
+	}
 
 	public final void setAlpha(int n, int n2, int n3, int n4, final int n5) {
 		if (n >= this.imgdata.width || n2 >= this.imgdata.height) {

--- a/src/midp/javax/microedition/lcdui/Graphics.java
+++ b/src/midp/javax/microedition/lcdui/Graphics.java
@@ -257,14 +257,14 @@ public class Graphics
 		Profiler.drawRegionPixelCount += Math.abs(w * h);
 	}
 
-	public void drawRGB(final int[] array, final int n, final int n2, final int n3, final int n4, final int n5, final int n6, final boolean b) {
+	public void drawRGB(final int[] rgbData, final int offset, final int scanlength, final int x, final int y, final int width, final int height, final boolean processAlpha) {
 		++Profiler.drawCallCount;
-		if (array == null) {
+		if (rgbData == null) {
 			throw new NullPointerException();
 		}
-		this._drawRegion(emulator.graphics2D.b.method163(array, b, n, n2, n5, n6), 0, 0, n5, n6, this.impl.getTransform().newTransform(n5, n6, 0, n3, n4, 0), 16711680);
+		this._drawRegion(emulator.graphics2D.b.method163(rgbData, processAlpha, offset, scanlength, width, height), 0, 0, width, height, this.impl.getTransform().newTransform(width, height, 0, x, y, 0), 0xFF0000);
 		++Profiler.drawRGBCallCount;
-		Profiler.drawRGBPixelCount += Math.abs(n5 * n6);
+		Profiler.drawRGBPixelCount += Math.abs(width * height);
 	}
 
 	public void drawChar(final char c, final int n, final int n2, final int n3) {


### PR DESCRIPTION
Calling `lcdui.Graphics.drawRGB()` many times per frame caused significant fps drop, for example in GoF2 in leaving station scene or when displaying dialogues (fig. 1.). It's more noticable with higher resoulution.

I narrowed down the problem to `emulator.graphics2D.awt.ImageAWT.setData()` and worked around it doing a little deobfuscation in the process.

![obraz](https://github.com/user-attachments/assets/559a63c1-1553-4063-9afb-73912a64f1af)
 Figure 1. Left - post fix, right - before fix.
