### PR TITLE
Imporove memory view performance further

### DIFF
--- a/src/main/emulator/graphics2D/IImage.java
+++ b/src/main/emulator/graphics2D/IImage.java
@@ -51,4 +51,10 @@ public interface IImage {
 	void fill(int color);
 
 	void getRGB(int[] data, int off, int scan, int x, int y, int w, int h);
+
+	/**
+	 * Allows some copy optimizations to be applied.
+	 * Image is mutable dy default.
+	 */
+	void switchMutability(boolean mutable);
 }

--- a/src/main/emulator/graphics2D/c.java
+++ b/src/main/emulator/graphics2D/c.java
@@ -64,13 +64,21 @@ public final class c {
 			final PaletteData paletteData = new PaletteData(directColorModel.getRedMask(), directColorModel.getGreenMask(), directColorModel.getBlueMask());
 			final ImageData imageData = new ImageData(bufferedImage.getWidth(), bufferedImage.getHeight(), directColorModel.getPixelSize(), paletteData);
 			final WritableRaster raster = bufferedImage.getRaster();
-			final int[] array = new int[4];
+			int imgW = imageData.width;
+			final int[] awtPixels = new int[4 * imgW];
+			final int[] swtPixels = new int[imgW];
+
 			for (int i = 0; i < imageData.height; ++i) {
-				for (int j = 0; j < imageData.width; ++j) {
-					raster.getPixel(j, i, array);
-					imageData.setPixel(j, i, paletteData.getPixel(new RGB(array[0], array[1], array[2])));
-					if (directColorModel.hasAlpha()) {
-						imageData.setAlpha(j, i, array[3]);
+				raster.getPixels(0, i, imgW, 1, awtPixels);
+
+				for (int j = 0; j < imgW; ++j) {
+					RGB rgb = new RGB(awtPixels[j * 4 + 0], awtPixels[j * 4 + 1], awtPixels[j * 4 + 2]);
+					swtPixels[j] = paletteData.getPixel(rgb);
+				}
+				imageData.setPixels(0, i, imgW, swtPixels, 0);
+				if (directColorModel.hasAlpha()) {
+					for (int j = 0; j < imgW; ++j) {
+						imageData.setAlpha(j, i, awtPixels[j * 4 + 3]);
 					}
 				}
 			}

--- a/src/main/emulator/graphics2D/swt/ImageSWT.java
+++ b/src/main/emulator/graphics2D/swt/ImageSWT.java
@@ -301,6 +301,10 @@ public final class ImageSWT implements IImage {
 		// TODO
 	}
 
+	@Override
+	public void switchMutability(boolean mutable) {
+	}
+
 	private int method300(int x, int y, ImageData imgdata) {
 		final RGB rgb = imgdata.palette.getRGB(imgdata.getPixel(x, y));
 		return ((imgdata.getAlpha(x, y) & 0xFF) << 24) + ((rgb.red & 0xFF) << 16) + ((rgb.green & 0xFF) << 8) + (rgb.blue & 0xFF);

--- a/src/midp/javax/microedition/lcdui/Image.java
+++ b/src/midp/javax/microedition/lcdui/Image.java
@@ -65,7 +65,7 @@ public class Image {
 		if (this.xrayBuffer == null && Settings.xrayView) {
 			this.xrayBuffer = Emulator.getEmulator().newImage(this.getWidth(), this.getHeight(), true);
 		}
-
+		imageImpl.switchMutability(true);
 		return new Graphics(this.imageImpl, xrayBuffer);
 	}
 
@@ -83,7 +83,9 @@ public class Image {
 
 	private static Image decode(final byte[] array) throws IllegalArgumentException {
 		try {
-			return new Image(Emulator.getEmulator().newImage(array));
+			Image img = new Image(Emulator.getEmulator().newImage(array));
+			img.imageImpl.switchMutability(false);
+			return img;
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			Emulator.getEmulator().getLogStream().println("*** createImage error!! check it ***");
@@ -112,7 +114,8 @@ public class Image {
 	public static Image createImage(final int n, final int n2) {
 		if (n <= 0 || n2 <= 0) throw new IllegalArgumentException();
 		final Image image;
-		(image = new Image(Emulator.getEmulator().newImage(n, n2, false))).mutable = true;
+		image = new Image(Emulator.getEmulator().newImage(n, n2, false));
+		image.mutable = true;
 		if (Settings.xrayView)
 			image.xrayBuffer = Emulator.getEmulator().newImage(n, n2, true);
 		return image;
@@ -140,6 +143,7 @@ public class Image {
 		if (Settings.xrayView)
 			image2.xrayBuffer = Emulator.getEmulator().newImage(n6, n7, true, 0);
 		image2.getGraphics().drawRegion(image, n, n2, n3, n4, n5, 0, 0, 20);
+		image2.imageImpl.switchMutability(false);
 		image2.mutable = false;
 		return image2;
 	}
@@ -162,6 +166,7 @@ public class Image {
 	public static Image createRGBImage(final int[] array, final int n, final int n2, final boolean b) {
 		final Image image;
 		GraphicsUtils.setImageData((image = new Image(Emulator.getEmulator().newImage(n, n2, b))).imageImpl, array, b, 0, n, n, n2);
+		image.imageImpl.switchMutability(false);
 		return image;
 	}
 


### PR DESCRIPTION
У мемвью исторически два "ой": умирание игры от галки автоапдейта и скролл картинок в 5 фпс. Первое уже починено в 2.20.

Тут очень грязный насёр решающий второе. Оно точно где-то сломается и решает проблему не полностью но эффективно заметает её под ковёр.

В флеймграфах ниже канва скроллилась всё время (за счёт кинетики) кроме пары секунд на дотянуться до кнопки стоп, смотреть надо на пропорцию отрисовки мемвью относительно отрисовки EmulatorScreen.

До:
<img width="1647" height="560" alt="Снимок экрана_2025-09-14_04-17-30" src="https://github.com/user-attachments/assets/871511a4-93b7-450d-b3a4-2371a423a9c9" />

После:
<img width="1647" height="417" alt="Снимок экрана_2025-09-14_04-36-48" src="https://github.com/user-attachments/assets/42d353c6-39f2-4142-9203-15bb87a03b3e" />
