### PR TITLE
Minor deobfuscation of mmf-related classes

### DIFF
--- a/src/main/emulator/media/MMFPlayer.java
+++ b/src/main/emulator/media/MMFPlayer.java
@@ -10,7 +10,7 @@ public class MMFPlayer {
 		super();
 	}
 
-	public static boolean a() {
+	public static boolean initialize() {
 		if (MMFPlayer.initialized) {
 			return true;
 		}

--- a/src/main/emulator/media/MidiBuilder.java
+++ b/src/main/emulator/media/MidiBuilder.java
@@ -1,41 +1,41 @@
 package emulator.media;
 
 public final class MidiBuilder {
-	public int anInt1275;
-	public int anInt1277;
-	public int anInt1278;
-	public int anInt1279;
-	public int anInt1280;
-	public int anInt1281;
-	public int anInt1282;
-	public int anInt1283;
-	static int anInt1284;
-	byte[] aByteArray1276;
+	public int note;
+	public int durationType;
+	public int noteType;
+	public int octave;
+	public int tempo;
+	public int volume;
+	public int trackLengthOffset;
+	public int trackCountOffset;
+	static int currentOffset;
+	byte[] midiData;
 
 	public MidiBuilder() {
 		super();
-		this.aByteArray1276 = new byte[100];
-		MidiBuilder.anInt1284 = 0;
+		this.midiData = new byte[100];
+		MidiBuilder.currentOffset = 0;
 	}
 
-	public final byte[] method730() {
-		return this.aByteArray1276;
+	public final byte[] getMIDIData() {
+		return this.midiData;
 	}
 
-	private void method731(final int n, final int n2) {
-		if (MidiBuilder.anInt1284 + n2 >= this.aByteArray1276.length) {
+	private void writeInt(final int n, final int n2) {
+		if (MidiBuilder.currentOffset + n2 >= this.midiData.length) {
 			final int n3 = (n2 > 100) ? n2 : 100;
-			final byte[] array = new byte[this.aByteArray1276.length];
-			System.arraycopy(this.aByteArray1276, 0, array, 0, this.aByteArray1276.length);
-			System.arraycopy(array, 0, this.aByteArray1276 = new byte[array.length + n3], 0, array.length);
+			final byte[] array = new byte[this.midiData.length];
+			System.arraycopy(this.midiData, 0, array, 0, this.midiData.length);
+			System.arraycopy(array, 0, this.midiData = new byte[array.length + n3], 0, array.length);
 		}
 		for (int i = n2 - 1; i >= 0; --i) {
-			this.aByteArray1276[MidiBuilder.anInt1284++] = (byte) (n >> (i << 3) & 0xFF);
+			this.midiData[MidiBuilder.currentOffset++] = (byte) (n >> (i << 3) & 0xFF);
 		}
 	}
 
-	private void method732(final int n) {
-		if (n == this.aByteArray1276.length) {
+	private void resizeBuffer(final int n) {
+		if (n == this.midiData.length) {
 			return;
 		}
 		byte[] array2;
@@ -43,29 +43,29 @@ public final class MidiBuilder {
 		byte[] array3;
 		int n3;
 		int length;
-		if (n < this.aByteArray1276.length) {
-			final byte[] array = new byte[this.aByteArray1276.length];
-			System.arraycopy(this.aByteArray1276, 0, array, 0, this.aByteArray1276.length);
-			this.aByteArray1276 = new byte[n];
+		if (n < this.midiData.length) {
+			final byte[] array = new byte[this.midiData.length];
+			System.arraycopy(this.midiData, 0, array, 0, this.midiData.length);
+			this.midiData = new byte[n];
 			array2 = array;
 			n2 = 0;
-			array3 = this.aByteArray1276;
+			array3 = this.midiData;
 			n3 = 0;
 			length = n;
 		} else {
-			final byte[] array4 = new byte[this.aByteArray1276.length];
-			System.arraycopy(this.aByteArray1276, 0, array4, 0, this.aByteArray1276.length);
-			this.aByteArray1276 = new byte[n];
+			final byte[] array4 = new byte[this.midiData.length];
+			System.arraycopy(this.midiData, 0, array4, 0, this.midiData.length);
+			this.midiData = new byte[n];
 			array2 = array4;
 			n2 = 0;
-			array3 = this.aByteArray1276;
+			array3 = this.midiData;
 			n3 = 0;
 			length = array4.length;
 		}
 		System.arraycopy(array2, n2, array3, n3, length);
 	}
 
-	private void method735(final int n) {
+	private void writeVariableLengthQuantity(final int n) {
 		int n2 = 7;
 		int n3;
 		while (true) {
@@ -91,40 +91,40 @@ public final class MidiBuilder {
 				a = this;
 				n7 = (n >> n6 & 0x7F);
 			}
-			a.method731(n7, 1);
+			a.writeInt(n7, 1);
 			n4 = (n5 = n6 - 7);
 		}
 	}
 
-	public final void method733() {
-		this.method731(1297377380, 4);
-		this.method731(6, 4);
-		this.method731(1, 2);
-		this.anInt1283 = MidiBuilder.anInt1284;
-		this.method731(1, 2);
-		this.method731(240, 2);
-		this.method731(1297379947, 4);
-		this.anInt1282 = MidiBuilder.anInt1284;
-		this.method731(0, 4);
-		this.method735(0);
-		this.method731(192, 1);
-		this.method731(80, 1); // replaced from 64
-		this.method737();
+	public final void initTrack() {
+		this.writeInt(1297377380, 4);
+		this.writeInt(6, 4);
+		this.writeInt(1, 2);
+		this.trackCountOffset = MidiBuilder.currentOffset;
+		this.writeInt(1, 2);
+		this.writeInt(240, 2);
+		this.writeInt(1297379947, 4);
+		this.trackLengthOffset = MidiBuilder.currentOffset;
+		this.writeInt(0, 4);
+		this.writeVariableLengthQuantity(0);
+		this.writeInt(192, 1);
+		this.writeInt(80, 1); // replaced from 64
+		this.setTempo();
 	}
 
-	public final void method736() {
-		int n = (int) (240.0f * (4.0f / (1 << this.anInt1277)));
+	public final void addNote() {
+		int n = (int) (240.0f * (4.0f / (1 << this.durationType)));
 		Label_0047:
 		{
 			int n2;
 			int n3;
 			int n4;
-			if (this.anInt1278 == 1) {
+			if (this.noteType == 1) {
 				n2 = n;
 				n3 = n;
 				n4 = 2;
 			} else {
-				if (this.anInt1278 != 2) {
+				if (this.noteType != 2) {
 					break Label_0047;
 				}
 				n2 = n + n / 2;
@@ -133,74 +133,74 @@ public final class MidiBuilder {
 			}
 			n = n2 + n3 / n4;
 		}
-		this.method735(0);
-		this.method731(144, 1);
+		this.writeVariableLengthQuantity(0);
+		this.writeInt(144, 1);
 		MidiBuilder a;
 		int n5;
-		if (this.anInt1275 == 0) {
+		if (this.note == 0) {
 			a = this;
 			n5 = 0;
 		} else {
 			a = this;
-			n5 = 60 + (this.anInt1275 - 1) + this.anInt1279 * 12;
+			n5 = 60 + (this.note - 1) + this.octave * 12;
 		}
-		a.method731(n5, 1);
-		this.method731(255, 1);
-		this.method735(n);
-		this.method731(128, 1);
+		a.writeInt(n5, 1);
+		this.writeInt(255, 1);
+		this.writeVariableLengthQuantity(n);
+		this.writeInt(128, 1);
 		MidiBuilder a2;
 		int n6;
-		if (this.anInt1275 == 0) {
-			this.method731(0, 1);
+		if (this.note == 0) {
+			this.writeInt(0, 1);
 			a2 = this;
 			n6 = 0;
 		} else {
-			this.method731(60 + (this.anInt1275 - 1) + this.anInt1279 * 12, 1);
+			this.writeInt(60 + (this.note - 1) + this.octave * 12, 1);
 			int n7;
-			if ((n7 = (int) (255.0f * (this.anInt1281 / 14.0f))) > 255) {
+			if ((n7 = (int) (255.0f * (this.volume / 14.0f))) > 255) {
 				n7 = 255;
 			}
 			a2 = this;
 			n6 = n7;
 		}
-		a2.method731(n6, 1);
+		a2.writeInt(n6, 1);
 	}
 
-	public final void method737() {
-		this.method735(0);
-		this.method731(255, 1);
-		this.method731(81, 1);
-		this.method731(3, 1);
+	public final void setTempo() {
+		this.writeVariableLengthQuantity(0);
+		this.writeInt(255, 1);
+		this.writeInt(81, 1);
+		this.writeInt(3, 1);
 		// tempo
-		final int n = this.anInt1280 == 0 ? 60000000 / 250 : 60000000 / this.anInt1280;
-		this.method731(n >> 16, 1);
-		this.method731(n >> 8 & 0xFF, 1);
-		this.method731(n & 0xFF, 1);
+		final int n = this.tempo == 0 ? 60000000 / 250 : 60000000 / this.tempo;
+		this.writeInt(n >> 16, 1);
+		this.writeInt(n >> 8 & 0xFF, 1);
+		this.writeInt(n & 0xFF, 1);
 	}
 
-	public final void method738() {
-		this.method735(0);
-		this.method731(255, 1);
-		this.method731(47, 1);
-		this.method731(0, 1);
-		final int anInt1284 = MidiBuilder.anInt1284;
-		MidiBuilder.anInt1284 = this.anInt1282;
-		this.method731(anInt1284 - this.anInt1282 - 4, 4);
-		this.method732(MidiBuilder.anInt1284 = anInt1284);
-		this.method734(this.anInt1282 - 4, MidiBuilder.anInt1284, 10);
+	public final void finishTrack() {
+		this.writeVariableLengthQuantity(0);
+		this.writeInt(255, 1);
+		this.writeInt(47, 1);
+		this.writeInt(0, 1);
+		final int anInt1284 = MidiBuilder.currentOffset;
+		MidiBuilder.currentOffset = this.trackLengthOffset;
+		this.writeInt(anInt1284 - this.trackLengthOffset - 4, 4);
+		this.resizeBuffer(MidiBuilder.currentOffset = anInt1284);
+		this.copyTrackData(this.trackLengthOffset - 4, MidiBuilder.currentOffset, 10);
 	}
 
-	private void method734(final int n, final int n2, final int n3) {
+	private void copyTrackData(final int n, final int n2, final int n3) {
 		final int n4 = n2 - n;
-		int n5 = this.aByteArray1276.length;
+		int n5 = this.midiData.length;
 		for (int i = 0; i < n3; ++i) {
-			this.method732(n5 + n4);
-			System.arraycopy(this.aByteArray1276, n, this.aByteArray1276, n5, n4);
-			n5 = this.aByteArray1276.length;
+			this.resizeBuffer(n5 + n4);
+			System.arraycopy(this.midiData, n, this.midiData, n5, n4);
+			n5 = this.midiData.length;
 		}
-		final int anInt1284 = MidiBuilder.anInt1284;
-		MidiBuilder.anInt1284 = this.anInt1283;
-		this.method731(n3 + 1, 2);
-		MidiBuilder.anInt1284 = anInt1284;
+		final int anInt1284 = MidiBuilder.currentOffset;
+		MidiBuilder.currentOffset = this.trackCountOffset;
+		this.writeInt(n3 + 1, 2);
+		MidiBuilder.currentOffset = anInt1284;
 	}
 }

--- a/src/nokia/com/nokia/mid/sound/Sound.java
+++ b/src/nokia/com/nokia/mid/sound/Sound.java
@@ -94,7 +94,7 @@ public class Sound {
 		if (paramInt == 1) {
 			// TODO fix memory leaks
 			if (Settings.enableOTT) {
-				paramArrayOfByte = new RingtoneParser(paramArrayOfByte).method726();
+				paramArrayOfByte = new RingtoneParser(paramArrayOfByte).getMIDIData();
 			} else {
 				m_player = new MIDITonePlayer();
 				state = 3;

--- a/src/oem/com/samsung/util/AudioClip.java
+++ b/src/oem/com/samsung/util/AudioClip.java
@@ -55,7 +55,7 @@ public class AudioClip {
 		}
 		this.type = type;
 		if (type == TYPE_MMF) {
-			this.mmfInit = MMFPlayer.a();
+			this.mmfInit = MMFPlayer.initialize();
 			this.data = b;
 			this.dataLen = b.length;
 			this.status = STATUS_STOP;


### PR DESCRIPTION
This was done primarily to integrate the freej2me-plus implementation of the MMF player in the future. The original one is proprietary and compiled for Win32. FJ2ME is not accurate at all, but it's better than nothing. So for Win32, the original stays, while the multiplatform version will use the new one.